### PR TITLE
Unified naming convention for all functions of the API

### DIFF
--- a/cmd_behave.c
+++ b/cmd_behave.c
@@ -122,7 +122,7 @@ int cmd_behave(context_t *context) {
         /* allow some time to pass to let the mouse really leave if we are on our way out */
         /* TODO(sissel): allow this delay to be tunable */
         usleep(100000); /* 100ms */
-        xdo_mousewindow(context->xdo, &hover);
+        xdo_get_window_at_mouse(context->xdo, &hover);
         if (hover == e.xcrossing.window) {
           //printf("Ignoring Leave, we're still in the window\n");
           break;

--- a/cmd_behave_screen_edge.c
+++ b/cmd_behave_screen_edge.c
@@ -118,7 +118,7 @@ int cmd_behave_screen_edge(context_t *context) {
   search.require = SEARCH_ANY;
   search.searchmask = SEARCH_NAME;
   search.winname = "^"; /* Match anything */
-  xdo_window_search(context->xdo, &search, &windowlist, &nwindows);
+  xdo_search_windows(context->xdo, &search, &windowlist, &nwindows);
   int i;
   for (i = 0; i < nwindows; i++) {
     XSelectInput(context->xdo->xdpy, windowlist[i], PointerMotionMask | SubstructureNotifyMask);

--- a/cmd_click.c
+++ b/cmd_click.c
@@ -90,9 +90,9 @@ int cmd_click(context_t *context) {
       xdo_clear_active_modifiers(context->xdo, window, active_mods);
     }
 
-    ret = xdo_click_multiple(context->xdo, window, button, repeat, delay);
+    ret = xdo_click_window_multiple(context->xdo, window, button, repeat, delay);
     if (ret != XDO_SUCCESS) {
-      fprintf(stderr, "xdo_click failed on window %ld\n", window);
+      fprintf(stderr, "xdo_click_window failed on window %ld\n", window);
       return ret;
     }
 

--- a/cmd_getactivewindow.c
+++ b/cmd_getactivewindow.c
@@ -29,7 +29,7 @@ int cmd_getactivewindow(context_t *context) {
 
   consume_args(context, optind);
 
-  ret = xdo_window_get_active(context->xdo, &window);
+  ret = xdo_get_active_window(context->xdo, &window);
 
   if (ret) {
     fprintf(stderr, "xdo_get_active_window reported an error\n");

--- a/cmd_getmouselocation.c
+++ b/cmd_getmouselocation.c
@@ -37,7 +37,7 @@ int cmd_getmouselocation(context_t *context) {
 
   consume_args(context, optind);
 
-  ret = xdo_mouselocation2(context->xdo, &x, &y, &screen_num, &window);
+  ret = xdo_get_mouse_location2(context->xdo, &x, &y, &screen_num, &window);
 
   if (output_shell) {
     xdotool_output(context, "X=%d", x);

--- a/cmd_getwindowfocus.c
+++ b/cmd_getwindowfocus.c
@@ -45,13 +45,13 @@ int cmd_getwindowfocus(context_t *context) {
   //}
 
   if (get_toplevel_focus) {
-    ret = xdo_window_sane_get_focus(context->xdo, &window);
+    ret = xdo_get_focused_window_sane(context->xdo, &window);
   } else {
-    ret = xdo_window_get_focus(context->xdo, &window);
+    ret = xdo_get_focused_window(context->xdo, &window);
   }
 
   if (ret) {
-    fprintf(stderr, "xdo_window_focus reported an error\n");
+    fprintf(stderr, "xdo_focus_window reported an error\n");
   } else { 
     /* only print if we're the last command */
     if (context->argc == 0) {

--- a/cmd_getwindowpid.c
+++ b/cmd_getwindowpid.c
@@ -37,7 +37,7 @@ int cmd_getwindowpid(context_t *context) {
   }
 
   window_each(context, window_arg, {
-    pid = xdo_window_get_pid(context->xdo, window);
+    pid = xdo_get_pid_window(context->xdo, window);
     if (pid == 0) {
       /* TODO(sissel): probably shouldn't exit failure when iterating over
        * a list of windows. What should we do? */

--- a/cmd_key.c
+++ b/cmd_key.c
@@ -85,11 +85,11 @@ int cmd_key(context_t *context) {
   int (*keyfunc)(const xdo_t *, Window, const char *, useconds_t) = NULL;
 
   if (!strcmp(cmd, "key")) {
-    keyfunc = xdo_keysequence;
+    keyfunc = xdo_send_keysequence_window;
   } else if (!strcmp(cmd, "keyup")) {
-    keyfunc = xdo_keysequence_up;
+    keyfunc = xdo_send_keysequence_window_up;
   } else if (!strcmp(cmd, "keydown")) {
-    keyfunc = xdo_keysequence_down;
+    keyfunc = xdo_send_keysequence_window_down;
   } else {
     fprintf(stderr, "Unknown command '%s'\n", cmd);
     return 1;
@@ -110,7 +110,7 @@ int cmd_key(context_t *context) {
       int tmp = keyfunc(context->xdo, window, context->argv[i], delay);
       if (tmp != 0) {
         fprintf(stderr,
-                "xdo_keysequence reported an error for string '%s'\n",
+                "xdo_send_keysequence_window reported an error for string '%s'\n",
                 context->argv[i]);
       }
       ret += tmp;

--- a/cmd_mousedown.c
+++ b/cmd_mousedown.c
@@ -58,7 +58,7 @@ int cmd_mousedown(context_t *context) {
       xdo_clear_active_modifiers(context->xdo, window, active_mods);
     }
 
-    ret = xdo_mousedown(context->xdo, window, button);
+    ret = xdo_mouse_down(context->xdo, window, button);
 
     if (clear_modifiers) {
       xdo_set_active_modifiers(context->xdo, window, active_mods);
@@ -66,7 +66,7 @@ int cmd_mousedown(context_t *context) {
     }
 
     if (ret) {
-      fprintf(stderr, "xdo_mousedown reported an error on window %ld\n", window);
+      fprintf(stderr, "xdo_mouse_down reported an error on window %ld\n", window);
       return ret;
     }
   }); /* window_each(...) */

--- a/cmd_mousemove.c
+++ b/cmd_mousemove.c
@@ -146,7 +146,7 @@ static int _mousemove(context_t *context, struct mousemove *mousemove) {
   /* Save the mouse position if the window is CURRENTWINDOW */
   if (window == CURRENTWINDOW) {
     context->have_last_mouse = True;
-    xdo_mouselocation(context->xdo, &(context->last_mouse_x),
+    xdo_get_mouse_location(context->xdo, &(context->last_mouse_x),
                       &(context->last_mouse_y), &(context->last_mouse_screen));
   }
   
@@ -182,7 +182,7 @@ static int _mousemove(context_t *context, struct mousemove *mousemove) {
   }
 
   int mx, my, mscreen;
-  xdo_mouselocation(context->xdo, &mx, &my, &mscreen);
+  xdo_get_mouse_location(context->xdo, &mx, &my, &mscreen);
 
   /* Break early if we don't need to move */
   if (mx == x && my == y && mscreen == screen) {
@@ -196,9 +196,9 @@ static int _mousemove(context_t *context, struct mousemove *mousemove) {
 
   if (mousemove->step == 0) {
     if (window != CURRENTWINDOW && !mousemove->polar_coordinates) {
-      ret = xdo_mousemove_relative_to_window(context->xdo, window, x, y);
+      ret = xdo_move_mouse_relative_to_window(context->xdo, window, x, y);
     } else {
-      ret = xdo_mousemove(context->xdo, x, y, screen);
+      ret = xdo_move_mouse(context->xdo, x, y, screen);
     }
   } else {
     if (mx == x && my == y && mscreen == screen) {
@@ -209,18 +209,18 @@ static int _mousemove(context_t *context, struct mousemove *mousemove) {
     fprintf(stderr, "--step support not yet implemented\n");
 
     if (window > 0) {
-      ret = xdo_mousemove_relative_to_window(context->xdo, window, x, y);
+      ret = xdo_move_mouse_relative_to_window(context->xdo, window, x, y);
     } else {
-      ret = xdo_mousemove(context->xdo, x, y, screen);
+      ret = xdo_move_mouse(context->xdo, x, y, screen);
     }
   }
 
   if (ret) {
-    fprintf(stderr, "xdo_mousemove reported an error\n");
+    fprintf(stderr, "xdo_move_mouse reported an error\n");
   } else {
     if (mousemove->opsync) {
       /* Wait until the mouse moves away from its current position */
-      xdo_mouse_wait_for_move_from(context->xdo, mx, my);
+      xdo_wait_for_mouse_move_from(context->xdo, mx, my);
     }
   }
 

--- a/cmd_mousemove_relative.c
+++ b/cmd_mousemove_relative.c
@@ -100,17 +100,17 @@ int cmd_mousemove_relative(context_t *context) {
   }
 
   if (opsync) {
-    xdo_mouselocation(context->xdo, &origin_x, &origin_y, NULL);
+    xdo_get_mouse_location(context->xdo, &origin_x, &origin_y, NULL);
   }
 
-  ret = xdo_mousemove_relative(context->xdo, x, y);
+  ret = xdo_move_mouse_relative(context->xdo, x, y);
 
   if (ret) {
-    fprintf(stderr, "xdo_mousemove_relative reported an error\n");
+    fprintf(stderr, "xdo_move_mouse_relative reported an error\n");
   } else {
     if (opsync) {
       /* Wait until the mouse moves away from its current position */
-      xdo_mouse_wait_for_move_from(context->xdo, origin_x, origin_y);
+      xdo_wait_for_mouse_move_from(context->xdo, origin_x, origin_y);
     }
   }
 

--- a/cmd_mouseup.c
+++ b/cmd_mouseup.c
@@ -58,7 +58,7 @@ int cmd_mouseup(context_t *context) {
       xdo_clear_active_modifiers(context->xdo, window, active_mods);
     }
 
-    ret = xdo_mouseup(context->xdo, window, button);
+    ret = xdo_mouse_up(context->xdo, window, button);
 
     if (clear_modifiers) {
       xdo_set_active_modifiers(context->xdo, window, active_mods);
@@ -66,7 +66,7 @@ int cmd_mouseup(context_t *context) {
     }
 
     if (ret) {
-      fprintf(stderr, "xdo_mouseup reported an error on window %ld\n", window);
+      fprintf(stderr, "xdo_mouse_up reported an error on window %ld\n", window);
       return ret;
     }
   }); /* window_each(...) */

--- a/cmd_search.c
+++ b/cmd_search.c
@@ -165,7 +165,7 @@ int cmd_search(context_t *context) {
   consume_args(context, 1);
 
   do {
-    xdo_window_search(context->xdo, &search, &list, &nwindows);
+    xdo_search_windows(context->xdo, &search, &list, &nwindows);
 
     if (context->argc == 0) {
       /* only print if we're the last command */
@@ -182,7 +182,7 @@ int cmd_search(context_t *context) {
     }
   } while (op_sync && nwindows == 0);
 
-  /* Free old list as it's malloc'd by xdo_window_search */
+  /* Free old list as it's malloc'd by xdo_search_windows */
   if (context->windows != NULL) {
     free(context->windows);
   }

--- a/cmd_set_window.c
+++ b/cmd_set_window.c
@@ -85,18 +85,18 @@ int cmd_set_window(context_t *context) {
   /* TODO(sissel): error handling needed... */
   window_each(context, window_arg, {
     if (name)
-      xdo_window_setprop(context->xdo, window, "WM_NAME", name);
+      xdo_set_window_property(context->xdo, window, "WM_NAME", name);
     if (icon)
-      xdo_window_setprop(context->xdo, window, "WM_ICON_NAME", icon);
+      xdo_set_window_property(context->xdo, window, "WM_ICON_NAME", icon);
     if (role)
-      xdo_window_setprop(context->xdo, window, "WM_WINDOW_ROLE", role);
+      xdo_set_window_property(context->xdo, window, "WM_WINDOW_ROLE", role);
     if (classname || _class)
-      xdo_window_setclass(context->xdo, window, classname, _class);
+      xdo_set_window_class(context->xdo, window, classname, _class);
     if (override_redirect != -1)
-      xdo_window_set_override_redirect(context->xdo, window,
+      xdo_set_window_override_redirect(context->xdo, window,
                                        override_redirect);
     if (urgency != -1)
-      xdo_window_seturgency(context->xdo, window, urgency);
+      xdo_set_window_urgency(context->xdo, window, urgency);
   }); /* window_each(...) */
 
   return 0;

--- a/cmd_type.c
+++ b/cmd_type.c
@@ -183,10 +183,10 @@ int cmd_type(context_t *context) {
 
     for (i = 0; i < data_count; i++) {
       //printf("Typing: '%s'\n", context->argv[i]);
-      int tmp = xdo_type(context->xdo, window, data[i], delay);
+      int tmp = xdo_enter_text_window(context->xdo, window, data[i], delay);
 
       if (tmp) {
-        fprintf(stderr, "xdo_type reported an error\n");
+        fprintf(stderr, "xdo_enter_text_window reported an error\n");
       }
 
       ret += tmp;

--- a/cmd_window_select.c
+++ b/cmd_window_select.c
@@ -29,10 +29,10 @@ int cmd_window_select(context_t *context) {
 
   consume_args(context, optind);
 
-  ret = xdo_window_select_with_click(context->xdo, &window);
+  ret = xdo_select_window_with_click(context->xdo, &window);
 
   if (ret) {
-    fprintf(stderr, "xdo_window_select_with_click reported an error\n");
+    fprintf(stderr, "xdo_select_window_with_click reported an error\n");
   } else {
     /* only print if we're the last command */
     if (context->argc == 0) {

--- a/cmd_windowactivate.c
+++ b/cmd_windowactivate.c
@@ -47,14 +47,14 @@ int cmd_windowactivate(context_t *context) {
   }
 
   window_each(context, window_arg, {
-    ret = xdo_window_activate(context->xdo, window);
+    ret = xdo_activate_window(context->xdo, window);
     if (ret) {
-      fprintf(stderr, "xdo_window_activate on window:%ld reported an error\n",
+      fprintf(stderr, "xdo_activate_window on window:%ld reported an error\n",
               window);
       return ret;
     } else {
       if (opsync) {
-        xdo_window_wait_for_active(context->xdo, window, 1);
+        xdo_wait_for_window_active(context->xdo, window, 1);
       }
     }
   }); /* window_each(...) */

--- a/cmd_windowfocus.c
+++ b/cmd_windowfocus.c
@@ -46,13 +46,13 @@ int cmd_windowfocus(context_t *context) {
   }
 
   window_each(context, window_arg, {
-    ret = xdo_window_focus(context->xdo, window);
+    ret = xdo_focus_window(context->xdo, window);
     if (ret) {
-      fprintf(stderr, "xdo_window_focus reported an error\n");
+      fprintf(stderr, "xdo_focus_windofocus_window reported an error\n");
       return ret;
     } else {
       if (opsync) {
-        xdo_window_wait_for_focus(context->xdo, window, 1);
+        xdo_wait_for_window_focus(context->xdo, window, 1);
       }
     }
   }); /* window_each(...) */

--- a/cmd_windowkill.c
+++ b/cmd_windowkill.c
@@ -37,9 +37,9 @@ int cmd_windowkill(context_t *context) {
   }
 
   window_each(context, window_arg, {
-    ret = xdo_window_kill(context->xdo, window);
+    ret = xdo_kill_window(context->xdo, window);
     if (ret) {
-      fprintf(stderr, "xdo_window_kill reported an error on window %ld\n",
+      fprintf(stderr, "xdo_kill_window reported an error on window %ld\n",
               window);
     }
   }); /* window_each(...) */

--- a/cmd_windowmap.c
+++ b/cmd_windowmap.c
@@ -47,12 +47,12 @@ int cmd_windowmap(context_t *context) {
   }
 
   window_each(context, window_arg, {
-    ret = xdo_window_map(context->xdo, window);
+    ret = xdo_map_window(context->xdo, window);
     if (ret) {
-      fprintf(stderr, "xdo_window_map reported an error\n");
+      fprintf(stderr, "xdo_map_window reported an error\n");
     } else {
       if (opsync) {
-        xdo_window_wait_for_map_state(context->xdo, window, IsViewable);
+        xdo_wait_for_window_map_state(context->xdo, window, IsViewable);
       }
     }
   }); /* window_each(...) */

--- a/cmd_windowminimize.c
+++ b/cmd_windowminimize.c
@@ -48,12 +48,12 @@ int cmd_windowminimize(context_t *context) {
   }
 
   window_each(context, window_arg, {
-    ret = xdo_window_minimize(context->xdo, window);
+    ret = xdo_minimize_window(context->xdo, window);
     if (ret) {
-      fprintf(stderr, "xdo_window_minimize reported an error\n");
+      fprintf(stderr, "xdo_minimize_window reported an error\n");
     } else {
       if (opsync) {
-        xdo_window_wait_for_map_state(context->xdo, window, IsUnmapped);
+        xdo_wait_for_window_map_state(context->xdo, window, IsUnmapped);
       }
     }
   }); /* window_each(...) */

--- a/cmd_windowmove.c
+++ b/cmd_windowmove.c
@@ -136,10 +136,10 @@ static int _windowmove(context_t *context, struct windowmove *windowmove) {
   }
 
 
-  ret = xdo_window_move(context->xdo, windowmove->window, target_x, target_y);
+  ret = xdo_move_window(context->xdo, windowmove->window, target_x, target_y);
   if (ret) {
     fprintf(stderr,
-            "xdo_window_move reported an error while moving window %ld\n",
+            "xdo_move_window reported an error while moving window %ld\n",
             windowmove->window);
   } else {
     if (windowmove->opsync) {

--- a/cmd_windowraise.c
+++ b/cmd_windowraise.c
@@ -37,9 +37,9 @@ int cmd_windowraise(context_t *context) {
   }
 
   window_each(context, window_arg, {
-    ret = xdo_window_raise(context->xdo, window);
+    ret = xdo_raise_window(context->xdo, window);
     if (ret) {
-      fprintf(stderr, "xdo_window_raise reported an error on window %ld\n",
+      fprintf(stderr, "xdo_raise_window reported an error on window %ld\n",
               window);
     }
   }); /* window_each(...) */

--- a/cmd_windowreparent.c
+++ b/cmd_windowreparent.c
@@ -54,15 +54,15 @@ int cmd_windowreparent(context_t *context) {
 
   window_each(context, window_arg, {
     //printf("Reparenting %ld -> %ld\n", window, destination);
-    ret = xdo_window_reparent(context->xdo, window, destination);
+    ret = xdo_reparent_window(context->xdo, window, destination);
     if (ret) {
-      fprintf(stderr, "xdo_window_reparent reported an error on for "
+      fprintf(stderr, "xdo_reparent_window reported an error on for "
               "src=%ld, dest=%ld\n", window, destination);
     }
   }); /* window_each(...) */
 
   if (ret)
-    fprintf(stderr, "xdo_window_reparent reported an error\n");
+    fprintf(stderr, "xdo_reparent_window reported an error\n");
 
   return ret;
 }

--- a/cmd_windowsize.c
+++ b/cmd_windowsize.c
@@ -108,10 +108,10 @@ int cmd_windowsize(context_t *context) {
       unsigned int h = height;
       xdo_get_window_size(context->xdo, window, &original_w, &original_h);
       if (size_flags & SIZE_USEHINTS_X) {
-        xdo_window_translate_with_sizehint(context->xdo, window, w, h, &w, NULL);
+        xdo_translate_window_with_sizehint(context->xdo, window, w, h, &w, NULL);
       }
       if (size_flags & SIZE_USEHINTS_Y) {
-        xdo_window_translate_with_sizehint(context->xdo, window, w, h, NULL, &h);
+        xdo_translate_window_with_sizehint(context->xdo, window, w, h, NULL, &h);
       }
 
       if (original_w == w && original_h == h) {
@@ -120,16 +120,16 @@ int cmd_windowsize(context_t *context) {
       }
     }
 
-    ret = xdo_window_setsize(context->xdo, window, width, height, size_flags);
+    ret = xdo_set_window_size(context->xdo, window, width, height, size_flags);
     if (ret) {
-      fprintf(stderr, "xdo_window_setsize on window:%ld reported an error\n",
+      fprintf(stderr, "xdo_set_window_size on window:%ld reported an error\n",
               window);
       return ret;
     }
     if (opsync) {
-      //xdo_window_wait_for_size(context->xdo, window, width, height, 0,
+      //xdo_wait_for_window_size(context->xdo, window, width, height, 0,
                                //SIZE_TO);
-      xdo_window_wait_for_size(context->xdo, window, original_w, original_h, 0,
+      xdo_wait_for_window_size(context->xdo, window, original_w, original_h, 0,
                                SIZE_FROM);
     }
   }); /* window_each(...) */

--- a/cmd_windowunmap.c
+++ b/cmd_windowunmap.c
@@ -47,13 +47,13 @@ int cmd_windowunmap(context_t *context) {
   }
 
   window_each(context, window_arg, {
-    ret = xdo_window_unmap(context->xdo, window);
+    ret = xdo_unmap_window(context->xdo, window);
     if (ret) {
-      fprintf(stderr, "xdo_window_unmap reported an error\n");
+      fprintf(stderr, "xdo_unmap_window reported an error\n");
     }
 
     if (opsync) {
-      xdo_window_wait_for_map_state(context->xdo, window, IsUnmapped);
+      xdo_wait_for_window_map_state(context->xdo, window, IsUnmapped);
     }
   }); /* window_each(...) */
 

--- a/xdo.h
+++ b/xdo.h
@@ -40,7 +40,7 @@
 
 /**
  * CURRENTWINDOW is a special identify for xdo input faking (mouse and
- * keyboard) functions like xdo_keysequence that indicate we should target the
+ * keyboard) functions like xdo_send_keysequence_window that indicate we should target the
  * current window, not a specific window.
  *
  * Generally, this means we will use XTEST instead of XSendEvent when sending
@@ -140,38 +140,38 @@ typedef struct xdo_active_mods {
 
 /**
  * Search only window title. DEPRECATED - Use SEARCH_NAME
- * @see xdo_window_search
+ * @see xdo_search_windows
  */
 #define SEARCH_TITLE (1UL << 0)
 
 /**
  * Search only window class.
- * @see xdo_window_search
+ * @see xdo_search_windows
  */
 #define SEARCH_CLASS (1UL << 1)
 
 /**
  * Search only window name.
- * @see xdo_window_search
+ * @see xdo_search_windows
  */
 #define SEARCH_NAME (1UL << 2)
 
 /**
  * Search only window pid.
- * @see xdo_window_search
+ * @see xdo_search_windows
  */
 #define SEARCH_PID  (1UL << 3)
 
 /**
  * Search only visible windows.
- * @see xdo_window_search
+ * @see xdo_search_windows
  */
 #define SEARCH_ONLYVISIBLE  (1UL << 4)
 
 /**
  * Search only a specific screen. 
  * @see xdo_search.screen
- * @see xdo_window_search
+ * @see xdo_search_windows
  */
 #define SEARCH_SCREEN  (1UL << 5)
 
@@ -184,7 +184,7 @@ typedef struct xdo_active_mods {
 /**
  * Search a specific desktop
  * @see xdo_search.screen
- * @see xdo_window_search
+ * @see xdo_search_windows
  */
 #define SEARCH_DESKTOP (1UL << 7)
 
@@ -192,7 +192,7 @@ typedef struct xdo_active_mods {
 /**
  * The window search query structure.
  *
- * @see xdo_window_search
+ * @see xdo_search_windows
  */
 typedef struct xdo_search {
   const char *title;        /** pattern to test against a window title */
@@ -264,7 +264,7 @@ void xdo_free(xdo_t *xdo);
  * @param y the target Y coordinate on the screen in pixels.
  * @param screen the screen (number) you want to move on.
  */
-int xdo_mousemove(const xdo_t *xdo, int x, int y, int screen);
+int xdo_move_mouse(const xdo_t *xdo, int x, int y, int screen);
 
 /**
  * Move the mouse to a specific location relative to the top-left corner
@@ -273,7 +273,7 @@ int xdo_mousemove(const xdo_t *xdo, int x, int y, int screen);
  * @param x the target X coordinate on the screen in pixels.
  * @param y the target Y coordinate on the screen in pixels.
  */
-int xdo_mousemove_relative_to_window(const xdo_t *xdo, Window window, int x, int y);
+int xdo_move_mouse_relative_to_window(const xdo_t *xdo, Window window, int x, int y);
 
 /**
  * Move the mouse relative to it's current position.
@@ -281,7 +281,7 @@ int xdo_mousemove_relative_to_window(const xdo_t *xdo, Window window, int x, int
  * @param x the distance in pixels to move on the X axis.
  * @param y the distance in pixels to move on the Y axis.
  */
-int xdo_mousemove_relative(const xdo_t *xdo, int x, int y);
+int xdo_move_mouse_relative(const xdo_t *xdo, int x, int y);
 
 /**
  * Send a mouse press (aka mouse down) for a given button at the current mouse
@@ -291,7 +291,7 @@ int xdo_mousemove_relative(const xdo_t *xdo, int x, int y);
  * @param button The mouse button. Generally, 1 is left, 2 is middle, 3 is
  *    right, 4 is wheel up, 5 is wheel down.
  */
-int xdo_mousedown(const xdo_t *xdo, Window window, int button);
+int xdo_mouse_down(const xdo_t *xdo, Window window, int button);
 
 /**
  * Send a mouse release (aka mouse up) for a given button at the current mouse
@@ -301,7 +301,7 @@ int xdo_mousedown(const xdo_t *xdo, Window window, int button);
  * @param button The mouse button. Generally, 1 is left, 2 is middle, 3 is
  *    right, 4 is wheel up, 5 is wheel down.
  */
-int xdo_mouseup(const xdo_t *xdo, Window window, int button);
+int xdo_mouse_up(const xdo_t *xdo, Window window, int button);
 
 /**
  * Get the current mouse location (coordinates and screen number).
@@ -310,14 +310,14 @@ int xdo_mouseup(const xdo_t *xdo, Window window, int button);
  * @param y integer pointer where the Y coordinate will be stored
  * @param screen_num integer pointer where the screen number will be stored
  */
-int xdo_mouselocation(const xdo_t *xdo, int *x, int *y, int *screen_num);
+int xdo_get_mouse_location(const xdo_t *xdo, int *x, int *y, int *screen_num);
 
 /**
  * Get the window the mouse is currently over
  *
  * @param window_ret Winter pointer where the window will be stored.
  */
-int xdo_mousewindow(const xdo_t *xdo, Window *window_ret);
+int xdo_get_window_at_mouse(const xdo_t *xdo, Window *window_ret);
 
 /**
  * Get all mouse location-related data.
@@ -331,8 +331,8 @@ int xdo_mousewindow(const xdo_t *xdo, Window *window_ret);
  * @param window Window pointer where the window/client the mouse is over
  *   will be stored.
  */
-int xdo_mouselocation2(const xdo_t *xdo, int *x_ret, int *y_ret,
-                       int *screen_num_ret, Window *window_ret);
+int xdo_get_mouse_location2(const xdo_t *xdo, int *x_ret, int *y_ret,
+                            int *screen_num_ret, Window *window_ret);
 
 /**
  * Wait for the mouse to move from a location. This function will block
@@ -341,7 +341,7 @@ int xdo_mouselocation2(const xdo_t *xdo, int *x_ret, int *y_ret,
  * @param origin_x the X position you expect the mouse to move from
  * @param origin_y the Y position you expect the mouse to move from
  */
-int xdo_mouse_wait_for_move_from(const xdo_t *xdo, int origin_x, int origin_y);
+int xdo_wait_for_mouse_move_from(const xdo_t *xdo, int origin_x, int origin_y);
 
 /**
  * Wait for the mouse to move to a location. This function will block
@@ -350,7 +350,7 @@ int xdo_mouse_wait_for_move_from(const xdo_t *xdo, int origin_x, int origin_y);
  * @param dest_x the X position you expect the mouse to move to
  * @param dest_y the Y position you expect the mouse to move to
  */
-int xdo_mouse_wait_for_move_to(const xdo_t *xdo, int dest_x, int dest_y);
+int xdo_wait_for_mouse_move_to(const xdo_t *xdo, int dest_x, int dest_y);
 
 /**
  * Send a click for a specific mouse button at the current mouse location.
@@ -359,7 +359,7 @@ int xdo_mouse_wait_for_move_to(const xdo_t *xdo, int dest_x, int dest_y);
  * @param button The mouse button. Generally, 1 is left, 2 is middle, 3 is
  *    right, 4 is wheel up, 5 is wheel down.
  */
-int xdo_click(const xdo_t *xdo, Window window, int button);
+int xdo_click_window(const xdo_t *xdo, Window window, int button);
 
 /**
  * Send a one or more clicks for a specific mouse button at the current mouse
@@ -369,21 +369,21 @@ int xdo_click(const xdo_t *xdo, Window window, int button);
  * @param button The mouse button. Generally, 1 is left, 2 is middle, 3 is
  *    right, 4 is wheel up, 5 is wheel down.
  */
-int xdo_click_multiple(const xdo_t *xdo, Window window, int button,
+int xdo_click_window_multiple(const xdo_t *xdo, Window window, int button,
                        int repeat, useconds_t delay);
 
 /**
  * Type a string to the specified window.
  *
  * If you want to send a specific key or key sequence, such as "alt+l", you
- * want instead xdo_keysequence(...).
+ * want instead xdo_send_keysequence_window(...).
  *
  * @param window The window you want to send keystrokes to or CURRENTWINDOW
  * @param string The string to type, like "Hello world!"
  * @param delay The delay between keystrokes in microseconds. 12000 is a decent
  *    choice if you don't have other plans.
  */
-int xdo_type(const xdo_t *xdo, Window window, const char *string, useconds_t delay);
+int xdo_enter_text_window(const xdo_t *xdo, Window window, const char *string, useconds_t delay);
 
 /**
  * Send a keysequence to the specified window.
@@ -399,30 +399,30 @@ int xdo_type(const xdo_t *xdo, Window window, const char *string, useconds_t del
  *   "Alt_L+Tab"
  *
  * If you want to type a string, such as "Hello world." you want to instead
- * use xdo_type.
+ * use xdo_enter_text_window.
  *
  * @param window The window you want to send the keysequence to or
  *   CURRENTWINDOW
  * @param keysequence The string keysequence to send.
  * @param delay The delay between keystrokes in microseconds.
  */
-int xdo_keysequence(const xdo_t *xdo, Window window,
+int xdo_send_keysequence_window(const xdo_t *xdo, Window window,
                     const char *keysequence, useconds_t delay);
 
 /**
  * Send key release (up) events for the given key sequence.
  *
- * @see xdo_keysequence
+ * @see xdo_send_keysequence_window
  */
-int xdo_keysequence_up(const xdo_t *xdo, Window window,
+int xdo_send_keysequence_window_up(const xdo_t *xdo, Window window,
                        const char *keysequence, useconds_t delay);
 
 /**
  * Send key press (down) events for the given key sequence.
  *
- * @see xdo_keysequence
+ * @see xdo_send_keysequence_window
  */
-int xdo_keysequence_down(const xdo_t *xdo, Window window,
+int xdo_send_keysequence_window_down(const xdo_t *xdo, Window window,
                          const char *keysequence, useconds_t delay);
                          
 /**
@@ -436,7 +436,7 @@ int xdo_keysequence_down(const xdo_t *xdo, Window window,
  *   the keys being pressed. If NULL, we don't save the modifiers.
  * @param delay The delay between keystrokes in microseconds.
  */
-int xdo_keysequence_list_do(const xdo_t *xdo, Window window,
+int xdo_send_keysequence_window_list_do(const xdo_t *xdo, Window window,
                             charcodemap_t *keys, int nkeys,
                             int pressed, int *modifier, useconds_t delay);
 
@@ -447,7 +447,7 @@ int xdo_keysequence_list_do(const xdo_t *xdo, Window window,
  *    by this function.
  * @param nkeys Pointer to integer where the number of keys will be stored.
  */
-int xdo_active_keys_to_keycode_list(const xdo_t *xdo, charcodemap_t **keys,
+int xdo_get_active_keys_to_keycode_list(const xdo_t *xdo, charcodemap_t **keys,
                                          int *nkeys);
 
 /**
@@ -462,11 +462,11 @@ int xdo_active_keys_to_keycode_list(const xdo_t *xdo, charcodemap_t **keys,
  * @param wid the window you want to wait for.
  * @param map_state the state to wait for.
  */
-int xdo_window_wait_for_map_state(const xdo_t *xdo, Window wid, int map_state);
+int xdo_wait_for_window_map_state(const xdo_t *xdo, Window wid, int map_state);
 
 #define SIZE_TO 0
 #define SIZE_FROM 1
-int xdo_window_wait_for_size(const xdo_t *xdo, Window window, unsigned int width,
+int xdo_wait_for_window_size(const xdo_t *xdo, Window window, unsigned int width,
                              unsigned int height, int flags, int to_or_from);
 
 
@@ -479,7 +479,7 @@ int xdo_window_wait_for_size(const xdo_t *xdo, Window window, unsigned int width
  * @param x the X coordinate to move to.
  * @param y the Y coordinate to move to.
  */
-int xdo_window_move(const xdo_t *xdo, Window wid, int x, int y);
+int xdo_move_window(const xdo_t *xdo, Window wid, int x, int y);
 
 /**
  * Apply a window's sizing hints (if any) to a given width and height.
@@ -493,7 +493,7 @@ int xdo_window_move(const xdo_t *xdo, Window wid, int x, int y);
  * @param width_ret the return location of the translated width
  * @param height_ret the return locatino of the translated height
  */
-int xdo_window_translate_with_sizehint(const xdo_t *xdo, Window window,
+int xdo_translate_window_with_sizehint(const xdo_t *xdo, Window window,
                                        int width, int height, int *width_ret,
                                        int *height_ret);
 
@@ -506,7 +506,7 @@ int xdo_window_translate_with_sizehint(const xdo_t *xdo, Window window,
  * @param flags if 0, use pixels for units. If SIZE_USEHINTS, then
  *   the units will be relative to the window size hints.
  */
-int xdo_window_setsize(const xdo_t *xdo, Window wid, int w, int h, int flags);
+int xdo_set_window_size(const xdo_t *xdo, Window wid, int w, int h, int flags);
 
 /**
  * Change a window property.
@@ -517,7 +517,7 @@ int xdo_window_setsize(const xdo_t *xdo, Window wid, int w, int h, int flags);
  * @param property the string name of the property.
  * @param value the string value of the property.
  */
-int xdo_window_setprop (const xdo_t *xdo, Window wid, const char *property,
+int xdo_set_window_property(const xdo_t *xdo, Window wid, const char *property,
                         const char *value);
 
 /**
@@ -526,13 +526,13 @@ int xdo_window_setprop (const xdo_t *xdo, Window wid, const char *property,
  * @param name The new class name. If NULL, no change.
  * @param _class The new class. If NULL, no change.
  */
-int xdo_window_setclass(const xdo_t *xdo, Window wid, const char *name,
+int xdo_set_window_class(const xdo_t *xdo, Window wid, const char *name,
                         const char *_class);
 
 /**
  * Sets the urgency hint for a window.
  */
-int xdo_window_seturgency (const xdo_t *xdo, Window wid, int urgency);
+int xdo_set_window_urgency (const xdo_t *xdo, Window wid, int urgency);
 
 /**
  * Set the override_redirect value for a window. This generally means
@@ -543,16 +543,16 @@ int xdo_window_seturgency (const xdo_t *xdo, Window wid, int urgency);
  * normal application window.
  *
  */
-int xdo_window_set_override_redirect(const xdo_t *xdo, Window wid,
+int xdo_set_window_override_redirect(const xdo_t *xdo, Window wid,
                                      int override_redirect);
 
 /**
  * Focus a window.
  *
- * @see xdo_window_activate
+ * @see xdo_activate_window
  * @param wid the window to focus.
  */
-int xdo_window_focus(const xdo_t *xdo, Window wid);
+int xdo_focus_window(const xdo_t *xdo, Window wid);
 
 /**
  * Raise a window to the top of the window stack. This is also sometimes
@@ -560,7 +560,7 @@ int xdo_window_focus(const xdo_t *xdo, Window wid);
  *
  * @param wid The window to raise.
  */
-int xdo_window_raise(const xdo_t *xdo, Window wid);
+int xdo_raise_window(const xdo_t *xdo, Window wid);
 
 /**
  * Get the window currently having focus.
@@ -568,7 +568,7 @@ int xdo_window_raise(const xdo_t *xdo, Window wid);
  * @param window_ret Pointer to a window where the currently-focused window
  *   will be stored.
  */
-int xdo_window_get_focus(const xdo_t *xdo, Window *window_ret);
+int xdo_get_focused_window(const xdo_t *xdo, Window *window_ret);
 
 /**
  * Wait for a window to have or lose focus.
@@ -576,7 +576,7 @@ int xdo_window_get_focus(const xdo_t *xdo, Window *window_ret);
  * @param window The window to wait on
  * @param want_focus If 1, wait for focus. If 0, wait for loss of focus.
  */
-int xdo_window_wait_for_focus(const xdo_t *xdo, Window window, int want_focus);
+int xdo_wait_for_window_focus(const xdo_t *xdo, Window window, int want_focus);
 
 /**
  * Get the PID owning a window. Not all applications support this.
@@ -585,10 +585,10 @@ int xdo_window_wait_for_focus(const xdo_t *xdo, Window window, int want_focus);
  * @param window the window to query.
  * @return the process id or 0 if no pid found.
  */
-int xdo_window_get_pid(const xdo_t *xdo, Window window);
+int xdo_get_pid_window(const xdo_t *xdo, Window window);
 
 /**
- * Like xdo_window_get_focus, but return the first ancestor-or-self window *
+ * Like xdo_get_focused_window, but return the first ancestor-or-self window *
  * having a property of WM_CLASS. This allows you to get the "real" or
  * top-level-ish window having focus rather than something you may not expect
  * to be the window having focused.
@@ -596,10 +596,10 @@ int xdo_window_get_pid(const xdo_t *xdo, Window window);
  * @param window_ret Pointer to a window where the currently-focused window
  *   will be stored.
  */
-int xdo_window_sane_get_focus(const xdo_t *xdo, Window *window_ret);
+int xdo_get_focused_window_sane(const xdo_t *xdo, Window *window_ret);
 
 /**
- * Activate a window. This is generally a better choice than xdo_window_focus
+ * Activate a window. This is generally a better choice than xdo_focus_window
  * for a variety of reasons, but it requires window manager support:
  *   - If the window is on another desktop, that desktop is switched to.
  *   - It moves the window forward rather than simply focusing it
@@ -609,7 +609,7 @@ int xdo_window_sane_get_focus(const xdo_t *xdo, Window *window_ret);
  *
  * @param wid the window to activate
  */
-int xdo_window_activate(const xdo_t *xdo, Window wid);
+int xdo_activate_window(const xdo_t *xdo, Window wid);
 
 /**
  * Wait for a window to be active or not active.
@@ -620,7 +620,7 @@ int xdo_window_activate(const xdo_t *xdo, Window wid);
  * @param window the window to wait on
  * @param active If 1, wait for active. If 0, wait for inactive.
  */
-int xdo_window_wait_for_active(const xdo_t *xdo, Window window, int active);
+int xdo_wait_for_window_active(const xdo_t *xdo, Window window, int active);
 
 /**
  * Map a window. This mostly means to make the window visible if it is
@@ -628,19 +628,19 @@ int xdo_window_wait_for_active(const xdo_t *xdo, Window window, int active);
  *
  * @param wid the window to map.
  */
-int xdo_window_map(const xdo_t *xdo, Window wid);
+int xdo_map_window(const xdo_t *xdo, Window wid);
 
 /**
  * Unmap a window
  *
  * @param wid the window to unmap
  */
-int xdo_window_unmap(const xdo_t *xdo, Window wid);
+int xdo_unmap_window(const xdo_t *xdo, Window wid);
 
 /**
  * Minimize a window.
  */
-int xdo_window_minimize(const xdo_t *xdo, Window wid);
+int xdo_minimize_window(const xdo_t *xdo, Window wid);
 
 /** 
  * Reparents a window
@@ -648,7 +648,7 @@ int xdo_window_minimize(const xdo_t *xdo, Window wid);
  * @param wid_source the window to reparent
  * @param wid_target the new parent window
  */
-int xdo_window_reparent(const xdo_t *xdo, Window wid_source, Window wid_target);
+int xdo_reparent_window(const xdo_t *xdo, Window wid_source, Window wid_target);
 
 /**
  * Get a window's location.
@@ -683,7 +683,7 @@ int xdo_get_window_size(const xdo_t *xdo, Window wid, unsigned int *width_ret,
  *
  * @param window_ret Pointer to Window where the active window is stored.
  */
-int xdo_window_get_active(const xdo_t *xdo, Window *window_ret);
+int xdo_get_active_window(const xdo_t *xdo, Window *window_ret);
 
 /**
  * Get a window ID by clicking on it. This function blocks until a selection
@@ -691,7 +691,7 @@ int xdo_window_get_active(const xdo_t *xdo, Window *window_ret);
  *
  * @param window_ret Pointer to Window where the selected window is stored.
  */
-int xdo_window_select_with_click(const xdo_t *xdo, Window *window_ret);
+int xdo_select_window_with_click(const xdo_t *xdo, Window *window_ret);
 
 /**
  * Set the number of desktops.
@@ -755,7 +755,7 @@ int xdo_get_desktop_for_window(const xdo_t *xdo, Window wid, long *desktop);
  * @param nwindows_ret the number of windows (length of windowlist_ret)
  * @see xdo_search_t
  */
-int xdo_window_search(const xdo_t *xdo, const xdo_search_t *search,
+int xdo_search_windows(const xdo_t *xdo, const xdo_search_t *search,
                       Window **windowlist_ret, int *nwindows_ret);
 
 /**
@@ -769,7 +769,7 @@ int xdo_window_search(const xdo_t *xdo, const xdo_search_t *search,
  * @return data consisting of 'nitems' items of size 'size' and type 'type'
  *   will need to be cast to the type before using.
  */
-unsigned char *xdo_getwinprop(const xdo_t *xdo, Window window, Atom atom,
+unsigned char *xdo_get_window_property(const xdo_t *xdo, Window window, Atom atom,
                               long *nitems, Atom *type, int *size);
 
 /**
@@ -785,7 +785,7 @@ unsigned int xdo_get_input_state(const xdo_t *xdo);
  * If you need the keysym-to-character map, you can fetch it using this method.
  * @see keysym_charmap_t
  */
-const keysym_charmap_t *xdo_keysym_charmap(void);
+const keysym_charmap_t *xdo_get_keysym_to_charmap(void);
 
 /**
  * If you need the symbol map, use this method.
@@ -795,7 +795,7 @@ const keysym_charmap_t *xdo_keysym_charmap(void);
  *
  * @returns array of strings.
  */
-const char **xdo_symbol_map(void);
+const char **xdo_get_symbol_map(void);
 
 /* active modifiers stuff */
 
@@ -845,7 +845,7 @@ int xdo_set_desktop_viewport(const xdo_t *xdo, int x, int y);
  * Kill a window and the client owning it.
  *
  */
-int xdo_window_kill(const xdo_t *xdo, Window window);
+int xdo_kill_window(const xdo_t *xdo, Window window);
 
 /**
  * Find a client window that is a parent of the window given
@@ -861,7 +861,7 @@ int xdo_window_kill(const xdo_t *xdo, Window window);
  * Find a client window (child) in a given window. Useful if you get the
  * window manager's decorator window rather than the client window.
  */
-int xdo_window_find_client(const xdo_t *xdo, Window window, Window *window_ret,
+int xdo_find_window_client(const xdo_t *xdo, Window window, Window *window_ret,
                            int direction);
 
 /**

--- a/xdo_search.c
+++ b/xdo_search.c
@@ -15,11 +15,11 @@
 
 static int compile_re(const char *pattern, regex_t *re);
 static int check_window_match(const xdo_t *xdo, Window wid, const xdo_search_t *search);
-static int _xdo_window_match_class(const xdo_t *xdo, Window window, regex_t *re);
-static int _xdo_window_match_classname(const xdo_t *xdo, Window window, regex_t *re);
-static int _xdo_window_match_name(const xdo_t *xdo, Window window, regex_t *re);
-static int _xdo_window_match_title(const xdo_t *xdo, Window window, regex_t *re);
-static int _xdo_window_match_pid(const xdo_t *xdo, Window window, int pid);
+static int _xdo_match_window_class(const xdo_t *xdo, Window window, regex_t *re);
+static int _xdo_match_window_classname(const xdo_t *xdo, Window window, regex_t *re);
+static int _xdo_match_window_name(const xdo_t *xdo, Window window, regex_t *re);
+static int _xdo_match_window_title(const xdo_t *xdo, Window window, regex_t *re);
+static int _xdo_match_window_pid(const xdo_t *xdo, Window window, int pid);
 static int _xdo_is_window_visible(const xdo_t *xdo, Window wid);
 static void find_matching_windows(const xdo_t *xdo, Window window, 
                                   const xdo_search_t *search,
@@ -28,7 +28,7 @@ static void find_matching_windows(const xdo_t *xdo, Window window,
                                   int *windowlist_size,
                                   int current_depth);
 
-int xdo_window_search(const xdo_t *xdo, const xdo_search_t *search,
+int xdo_search_windows(const xdo_t *xdo, const xdo_search_t *search,
                       Window **windowlist_ret, int *nwindows_ret) {
   int i = 0;
 
@@ -77,17 +77,17 @@ int xdo_window_search(const xdo_t *xdo, const xdo_search_t *search,
   //printf("//Search\n");
 
   return XDO_SUCCESS;
-} /* int xdo_window_search */
+} /* int xdo_search_windows */
 
-static int _xdo_window_match_title(const xdo_t *xdo, Window window, regex_t *re) {
+static int _xdo_match_window_title(const xdo_t *xdo, Window window, regex_t *re) {
   fprintf(stderr, "This function (match window by title) is deprecated."
           " You want probably want to match by the window name.\n");
-  return _xdo_window_match_name(xdo, window, re);
-} /* int _xdo_window_match_title */
+  return _xdo_match_window_name(xdo, window, re);
+} /* int _xdo_match_window_title */
 
-static int _xdo_window_match_name(const xdo_t *xdo, Window window, regex_t *re) {
+static int _xdo_match_window_name(const xdo_t *xdo, Window window, regex_t *re) {
   /* historically in xdo, 'match_name' matched the classhint 'name' which we
-   * match in _xdo_window_match_classname. But really, most of the time 'name'
+   * match in _xdo_match_window_classname. But really, most of the time 'name'
    * refers to the window manager name for the window, which is displayed in
    * the titlebar */
   int i;
@@ -118,9 +118,9 @@ static int _xdo_window_match_name(const xdo_t *xdo, Window window, regex_t *re) 
   XFreeStringList(list);
   XFree(tp.value);
   return False;
-} /* int _xdo_window_match_name */
+} /* int _xdo_match_window_name */
 
-static int _xdo_window_match_class(const xdo_t *xdo, Window window, regex_t *re) {
+static int _xdo_match_window_class(const xdo_t *xdo, Window window, regex_t *re) {
   XWindowAttributes attr;
   XClassHint classhint;
   XGetWindowAttributes(xdo->xdpy, window, &attr);
@@ -141,9 +141,9 @@ static int _xdo_window_match_class(const xdo_t *xdo, Window window, regex_t *re)
     }
   }
   return False;
-} /* int _xdo_window_match_class */
+} /* int _xdo_match_window_class */
 
-static int _xdo_window_match_classname(const xdo_t *xdo, Window window, regex_t *re) {
+static int _xdo_match_window_classname(const xdo_t *xdo, Window window, regex_t *re) {
   XWindowAttributes attr;
   XClassHint classhint;
   XGetWindowAttributes(xdo->xdpy, window, &attr);
@@ -163,18 +163,18 @@ static int _xdo_window_match_classname(const xdo_t *xdo, Window window, regex_t 
     }
   }
   return False;
-} /* int _xdo_window_match_classname */
+} /* int _xdo_match_window_classname */
 
-static int _xdo_window_match_pid(const xdo_t *xdo, Window window, const int pid) {
+static int _xdo_match_window_pid(const xdo_t *xdo, Window window, const int pid) {
   int window_pid;
 
-  window_pid = xdo_window_get_pid(xdo, window);
+  window_pid = xdo_get_pid_window(xdo, window);
   if (pid == window_pid) {
     return True;
   } else {
     return False;
   }
-} /* int _xdo_window_match_pid */
+} /* int _xdo_match_window_pid */
 
 static int compile_re(const char *pattern, regex_t *re) {
   int ret;
@@ -257,27 +257,27 @@ static int check_window_match(const xdo_t *xdo, Window wid,
       break;
     }
 
-    if (pid_want && !_xdo_window_match_pid(xdo, wid, search->pid)) {
+    if (pid_want && !_xdo_match_window_pid(xdo, wid, search->pid)) {
       if (debug) fprintf(stderr, "skip %ld pid\n", wid); 
       pid_ok = False;
     }
 
-    if (title_want && !_xdo_window_match_title(xdo, wid, &title_re)) {
+    if (title_want && !_xdo_match_window_title(xdo, wid, &title_re)) {
       if (debug) fprintf(stderr, "skip %ld title\n", wid);
       title_ok = False;
     }
 
-    if (name_want && !_xdo_window_match_name(xdo, wid, &name_re)) {
+    if (name_want && !_xdo_match_window_name(xdo, wid, &name_re)) {
       if (debug) fprintf(stderr, "skip %ld winname\n", wid);
       name_ok = False;
     }
 
-    if (class_want && !_xdo_window_match_class(xdo, wid, &class_re)) {
+    if (class_want && !_xdo_match_window_class(xdo, wid, &class_re)) {
       if (debug) fprintf(stderr, "skip %ld winclass\n", wid);
       class_ok = False;
     }
 
-    if (classname_want && !_xdo_window_match_classname(xdo, wid, &classname_re)) {
+    if (classname_want && !_xdo_match_window_classname(xdo, wid, &classname_re)) {
       if (debug) fprintf(stderr, "skip %ld winclassname\n", wid);
       classname_ok = False;
     }


### PR DESCRIPTION
Changed naming of functions so that they all comply to the
`xdo_verb_object_[...]` as far as possible. Some funny things
might still happen due to the name changes.
