### PR TITLE
Fix handling of empty files in type command.

### DIFF
--- a/cmd_type.c
+++ b/cmd_type.c
@@ -139,6 +139,8 @@ int cmd_type(context_t *context) {
       marker = buffer + bytes_read;
       if (fgets(marker, 4096, input) != NULL) {
         bytes_read = (marker - buffer) + strlen(marker);
+      } else {
+        *marker = 0;
       }
 
       if (ferror(input) != 0) {


### PR DESCRIPTION
This pull request fixes a bug in type where passing an empty file (length 0), either a standard input or a file, results in an uninitialized buffer being typed. The issue arises because on a successful read of 0 bytes, fgets does not write a null to the destination buffer, but because the read was successful ferror will return 0. To reproduce:

touch empty_file
valgrind ./xdotool type --file empty_file
