### PR TITLE
Fix memory issues, integer overflow, undefined behavior

### DIFF
--- a/cmd_getwindowname.c
+++ b/cmd_getwindowname.c
@@ -41,8 +41,10 @@ int cmd_getwindowname(context_t *context) {
 
   window_each(context, window_arg, {
     xdo_get_window_name(context->xdo, window, &name, &name_len, &name_type);
-    xdotool_output(context, "%.*s", name_len, name);
-    XFree(name);
+    if (name) {
+      xdotool_output(context, "%.*s", name_len, name);
+      XFree(name);
+    }
   }); /* window_each(...) */
   return EXIT_SUCCESS;
 }

--- a/cmd_mouseup.c
+++ b/cmd_mouseup.c
@@ -2,7 +2,7 @@
 #include <string.h>
 
 int cmd_mouseup(context_t *context) {
-  int ret = 0;
+  int ret = EXIT_FAILURE;
   int button;
   char *cmd = *context->argv;
   char *window_arg = NULL;
@@ -29,17 +29,18 @@ int cmd_mouseup(context_t *context) {
       case 'h':
         printf(usage, cmd);
         consume_args(context, context->argc);
-        return EXIT_SUCCESS;
-        break;
+        ret = EXIT_SUCCESS;
+        goto finalize;
       case 'c':
         clear_modifiers = 1;
         break;
       case 'w':
+        free(window_arg);
         window_arg = strdup(optarg);
         break;
       default:
         fprintf(stderr, usage, cmd);
-        return EXIT_FAILURE;
+        goto finalize;
     }
   }
 
@@ -47,11 +48,13 @@ int cmd_mouseup(context_t *context) {
 
   if (context->argc < 1) {
     fprintf(stderr, usage, cmd);
-    fprintf(stderr, "You specified the wrong number of args.\n");
-    return 1;
+    fprintf(stderr, "What button do you want me to release?\n");
+    goto finalize;
   }
 
   button = atoi(context->argv[0]);
+
+  ret = EXIT_SUCCESS;
 
   window_each(context, window_arg, {
     if (clear_modifiers) {
@@ -68,14 +71,13 @@ int cmd_mouseup(context_t *context) {
 
     if (ret) {
       fprintf(stderr, "xdo_mouse_up reported an error on window %ld\n", window);
-      return ret;
+      goto finalize;
     }
   }); /* window_each(...) */
 
-  if (window_arg != NULL) {
-    free(window_arg);
-  }
   consume_args(context, 1);
+finalize:
+  free(window_arg);
   return ret;
 }
 

--- a/cmd_type.c
+++ b/cmd_type.c
@@ -117,6 +117,11 @@ int cmd_type(context_t *context) {
     goto finalize;
   }
 
+  /* use %1 if there is a window stack */
+  if (window_arg == NULL && context->nwindows > 0) {
+    window_arg = strdup("%1");
+  }
+
   if (file != NULL) {
     data = calloc(1 + context->argc, sizeof(char *));
 

--- a/cmd_type.c
+++ b/cmd_type.c
@@ -4,7 +4,7 @@
 #include <errno.h>
 
 int cmd_type(context_t *context) {
-  int ret = 0;
+  int ret = EXIT_FAILURE;
   int i;
   int c;
   char *cmd = *context->argv;
@@ -66,6 +66,7 @@ int cmd_type(context_t *context) {
                                longopts, &option_index)) != -1) {
     switch (c) {
       case opt_window:
+        free(window_arg);
         window_arg = strdup(optarg);
         break;
       case opt_delay:
@@ -78,20 +79,22 @@ int cmd_type(context_t *context) {
       case opt_help:
         printf(usage, cmd);
         consume_args(context, context->argc);
-        return EXIT_SUCCESS;
-        break;
+        ret = EXIT_SUCCESS;
+        goto finalize;
       case opt_args:
         arity = atoi(optarg);
         break;
       case opt_terminator:
+        free(terminator);
         terminator = strdup(optarg);
         break;
       case opt_file:
-	file = strdup(optarg);
-	break;
+        free(file);
+        file = strdup(optarg);
+        break;
       default:
         fprintf(stderr, usage, cmd);
-        return EXIT_FAILURE;
+        goto finalize;
     }
   }
 
@@ -100,18 +103,18 @@ int cmd_type(context_t *context) {
   if (context->argc == 0 && file == NULL) {
     fprintf(stderr, "You specified the wrong number of args.\n");
     fprintf(stderr, usage, cmd);
-    return 1;
+    goto finalize;
   }
 
   if (arity > 0 && terminator != NULL) {
     fprintf(stderr, "Don't use both --terminator and --args.\n");
-    return EXIT_FAILURE;
+    goto finalize;
   }
 
   if (context->argc < arity) {
     fprintf(stderr, "You said '--args %d' but only gave %d arguments.\n",
             arity, context->argc);
-    return EXIT_FAILURE;
+    goto finalize;
   }
 
   if (file != NULL) {
@@ -124,7 +127,7 @@ int cmd_type(context_t *context) {
       input = fopen(file, "r");
       if (input == NULL) {
         fprintf(stderr, "Failure opening '%s': %s\n", file, strerror(errno));
-        return EXIT_FAILURE;
+        goto finalize;
       }
     }
 
@@ -132,7 +135,7 @@ int cmd_type(context_t *context) {
       marker = realloc(buffer, bytes_read + 4096);
       if (marker == NULL) {
         fprintf(stderr, "Failure allocating for '%s': %s\n", file, strerror(errno));
-        return EXIT_FAILURE;
+        goto finalize;
       }
 
       buffer = marker;
@@ -145,12 +148,13 @@ int cmd_type(context_t *context) {
 
       if (ferror(input) != 0) {
         fprintf(stderr, "Failure reading '%s': %s\n", file, strerror(errno));
-        return EXIT_FAILURE;
+        goto finalize;
       }
     }
 
     data[0] = buffer;
     data_count++;
+    buffer = NULL; /* prevent double-free */
 
     fclose(input);
   }
@@ -177,6 +181,13 @@ int cmd_type(context_t *context) {
     data_count++;
     args_count++;
   }
+  if (data[0] == NULL) {
+    fprintf(stderr, "Missing things to type.\n");
+    goto finalize;
+  }
+
+  /* pretend success unless one of the type commands fail */
+  ret = EXIT_SUCCESS;
 
   window_each(context, window_arg, {
     if (clear_modifiers) {
@@ -190,9 +201,8 @@ int cmd_type(context_t *context) {
 
       if (tmp) {
         fprintf(stderr, "xdo_enter_text_window reported an error\n");
+        ret = EXIT_FAILURE;
       }
-
-      ret += tmp;
     }
 
     if (clear_modifiers) {
@@ -201,11 +211,19 @@ int cmd_type(context_t *context) {
     }
   }); /* window_each(...) */
 
-  if (window_arg != NULL) {
-    free(window_arg);
-  }
-
   consume_args(context, args_count);
-  return ret > 0;
+
+finalize:
+  free(window_arg);
+  free(terminator);
+  free(file);
+  free(buffer);
+  if (data) {
+    for (i = 0; i < data_count; ++i) {
+      free(data[i]);
+    }
+  }
+  free(data);
+  return ret;
 }
 

--- a/cmd_windowunmap.c
+++ b/cmd_windowunmap.c
@@ -4,7 +4,7 @@ int cmd_windowunmap(context_t *context) {
   int ret = 0;
   char *cmd = *context->argv;
   const char *window_arg = "%1";
-  int opsync;
+  int opsync = 0;
 
   int c;
   typedef enum {

--- a/xdo.c
+++ b/xdo.c
@@ -123,6 +123,7 @@ xdo_t* xdo_new_with_opened_display(Display *xdpy, const char *display,
   if (display == NULL) {
     display = "unknown";
   }
+  xdo->display_name = display;
 
   if (getenv("XDO_QUIET")) {
     xdo->quiet = True;
@@ -146,8 +147,6 @@ void xdo_free(xdo_t *xdo) {
   if (xdo == NULL)
     return;
 
-  if (xdo->display_name)
-    free(xdo->display_name);
   if (xdo->charcodes)
     free(xdo->charcodes);
   if (xdo->xdpy && xdo->close_display_when_freed)

--- a/xdo.c
+++ b/xdo.c
@@ -1539,7 +1539,7 @@ int _xdo_send_keysequence_window_to_keycode_list(const xdo_t *xdo, const char *k
     (*nkeys)++;
     if (*nkeys == keys_size) {
       keys_size *= 2;
-      *keys = realloc(*keys, keys_size * sizeof(KeyCode));
+      *keys = realloc(*keys, keys_size * sizeof(charcodemap_t));
     }
   }
 

--- a/xdo.c
+++ b/xdo.c
@@ -278,8 +278,6 @@ int xdo_translate_window_with_sizehint(const xdo_t *xdo, Window window,
     height *= hints.height_inc;
   } else {
     fprintf(stderr, "No size hints found for window %ld\n", window);
-    *width_ret = width;
-    *height_ret = width;
   }
 
   if (supplied_return & PBaseSize) {

--- a/xdo.c
+++ b/xdo.c
@@ -407,6 +407,7 @@ int xdo_focus_window(const xdo_t *xdo, Window wid) {
 int xdo_wait_for_window_size(const xdo_t *xdo, Window window,
                              unsigned int width, unsigned int height,
                              int flags, int to_or_from) {
+  int ret;
   unsigned int cur_width, cur_height;
   /*unsigned int alt_width, alt_height;*/
 
@@ -428,20 +429,18 @@ int xdo_wait_for_window_size(const xdo_t *xdo, Window window,
   }
 
   int tries = MAX_TRIES;
-  xdo_get_window_size(xdo, window, &cur_width,
-                      &cur_height);
+  ret = xdo_get_window_size(xdo, window, &cur_width, &cur_height);
   //printf("Want: %udx%ud\n", width, height);
   //printf("Alt: %udx%ud\n", alt_width, alt_height);
-  while (tries > 0 && (to_or_from == SIZE_TO
+  while (!ret && tries > 0 && (to_or_from == SIZE_TO
          ? (cur_width != width && cur_height != height)
          : (cur_width == width && cur_height == height))) {
-    xdo_get_window_size(xdo, window, (unsigned int *)&cur_width,
-                        (unsigned int *)&cur_height);
+    ret = xdo_get_window_size(xdo, window, &cur_width, &cur_height);
     usleep(30000);
     tries--;
   }
 
-  return 0;
+  return ret;
 }
 
 int xdo_wait_for_window_active(const xdo_t *xdo, Window window, int active) {

--- a/xdo.h
+++ b/xdo.h
@@ -86,7 +86,7 @@ typedef struct xdo {
   Display *xdpy;
 
   /** The display name, if any. NULL if not specified. */
-  char *display_name;
+  const char *display_name;
 
   /** @internal Array of known keys/characters */
   charcodemap_t *charcodes;


### PR DESCRIPTION
These patch series fix 32 bugs reported by clang static analyzer (18 memory leaks, 11 use of undefined variables). Two unfixed bugs are at #35.

Note for "Set display_name field", if ABI breakage is allowed in the future, this field can probably be dropped.

Besides the bunch of memory leaks fixes, there are also other changes for unusual code paths:
- cmd_key: fix crash due to invalid calculation: `xdotool key shift+shift+shift+shift+shift+shift+shift+shift+shift+x`
- cmd_{type,exec}: these now crash if you use `xdotool type --terminator x x`
- Scripts can crash by using positional parameters that wrap negative (integer overflow): `echo '$4294967294' | xdotool -`

Fixes that are normally useful:
- Regexes are now pre-compiled, this should give some milliseconds better performance and error only out once when an invalid regex is encountered (e.g. `xdotool search --name '*'`)
- `xdotool search --name Firefox type foo` now types in the correct window.
