### PR TITLE
Change t/test_*.rb require to require_relative.

### DIFF
--- a/t/test_basic.rb
+++ b/t/test_basic.rb
@@ -2,7 +2,7 @@
 #
 
 require "test/unit"
-require "./xdo_test_helper"
+require_relative "xdo_test_helper"
 
 class XdotoolBasicTests < Test::Unit::TestCase
   include XdoTestHelper

--- a/t/test_chaining.rb
+++ b/t/test_chaining.rb
@@ -2,7 +2,7 @@
 #
 
 require "test/unit"
-require "./xdo_test_helper"
+require_relative "xdo_test_helper"
 
 class XdotoolChainingTests < Test::Unit::TestCase
   include XdoTestHelper

--- a/t/test_cmd_behave_screen_edge.rb
+++ b/t/test_cmd_behave_screen_edge.rb
@@ -2,7 +2,7 @@
 #
 
 require "test/unit"
-require "./xdo_test_helper"
+require_relative "xdo_test_helper"
 
 class XdotoolCommandBehaveScreenEdgeTests < Test::Unit::TestCase
   include XdoTestHelper

--- a/t/test_cmd_exec.rb
+++ b/t/test_cmd_exec.rb
@@ -3,7 +3,7 @@
 #
 
 require "test/unit"
-require "./xdo_test_helper"
+require_relative "xdo_test_helper"
 
 class XdotoolCommandExecTests < Test::Unit::TestCase
   include XdoTestHelper

--- a/t/test_cmd_getwindowname.rb
+++ b/t/test_cmd_getwindowname.rb
@@ -2,7 +2,7 @@
 #
 
 require "test/unit"
-require "./xdo_test_helper"
+require_relative "xdo_test_helper"
 
 class XdotoolCommandGetWindowPidTests < Test::Unit::TestCase
   include XdoTestHelper

--- a/t/test_cmd_getwindowpid.rb
+++ b/t/test_cmd_getwindowpid.rb
@@ -2,7 +2,7 @@
 #
 
 require "test/unit"
-require "./xdo_test_helper"
+require_relative "xdo_test_helper"
 
 class XdotoolCommandGetWindowPidTests < Test::Unit::TestCase
   include XdoTestHelper

--- a/t/test_cmd_key.rb
+++ b/t/test_cmd_key.rb
@@ -2,7 +2,7 @@
 #
 
 require "test/unit"
-require "./xdo_test_helper"
+require_relative "xdo_test_helper"
 
 class XdotoolCommandKeyTests < Test::Unit::TestCase
   include XdoTestHelper

--- a/t/test_cmd_windowfocus.rb
+++ b/t/test_cmd_windowfocus.rb
@@ -3,7 +3,7 @@
 #
 
 require "test/unit"
-require "./xdo_test_helper"
+require_relative "xdo_test_helper"
 
 class XdotoolCommandWindowFocusTests < Test::Unit::TestCase
   include XdoTestHelper

--- a/t/test_cmd_windowmap.rb
+++ b/t/test_cmd_windowmap.rb
@@ -3,7 +3,7 @@
 #
 
 require "test/unit"
-require "./xdo_test_helper"
+require_relative "xdo_test_helper"
 
 class XdotoolCommandWindowMapTests < Test::Unit::TestCase
   include XdoTestHelper

--- a/t/test_cmd_windowminimize.rb
+++ b/t/test_cmd_windowminimize.rb
@@ -2,7 +2,7 @@
 #
 
 require "test/unit"
-require "./xdo_test_helper"
+require_relative "xdo_test_helper"
 
 class XdotoolCommandWindowMinimizeTests < Test::Unit::TestCase
   include XdoTestHelper

--- a/t/test_cmd_windowmove.rb
+++ b/t/test_cmd_windowmove.rb
@@ -3,7 +3,7 @@
 #
 
 require "test/unit"
-require "./xdo_test_helper"
+require_relative "xdo_test_helper"
 
 class XdotoolCommandWindowMoveTests < Test::Unit::TestCase
   include XdoTestHelper

--- a/t/test_cmd_windowsize.rb
+++ b/t/test_cmd_windowsize.rb
@@ -3,7 +3,7 @@
 #
 
 require "test/unit"
-require "./xdo_test_helper"
+require_relative "xdo_test_helper"
 
 class XdotoolCommandWindowSizeTests < Test::Unit::TestCase
   include XdoTestHelper

--- a/t/test_mousemove.rb
+++ b/t/test_mousemove.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require "test/unit"
-require "./xdo_test_helper"
+require_relative "xdo_test_helper"
 
 class XdotoolMouseMoveTests < Test::Unit::TestCase
   include XdoTestHelper

--- a/t/test_script.rb
+++ b/t/test_script.rb
@@ -2,7 +2,7 @@
 #
 
 require "test/unit"
-require "./xdo_test_helper"
+require_relative "xdo_test_helper"
 require "tempfile"
 
 class XdotoolScriptTests < Test::Unit::TestCase

--- a/t/test_search.rb
+++ b/t/test_search.rb
@@ -2,7 +2,7 @@
 #
 
 require "test/unit"
-require "./xdo_test_helper"
+require_relative "xdo_test_helper"
 
 class XdotoolSearchTests < Test::Unit::TestCase
   include XdoTestHelper

--- a/t/test_typing.rb
+++ b/t/test_typing.rb
@@ -3,7 +3,7 @@
 
 require "test/unit"
 require "tempfile"
-require "./xdo_test_helper"
+require_relative "xdo_test_helper"
 
 class XdotoolTypingTests < Test::Unit::TestCase
   include XdoTestHelper

--- a/t/test_window.rb
+++ b/t/test_window.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require "test/unit"
-require "./xdo_test_helper"
+require_relative "xdo_test_helper"
 
 class XdotoolWindowTests < Test::Unit::TestCase
   include XdoTestHelper


### PR DESCRIPTION
require_relative has been supported since early in 1.9, and is generally
the preferred way to refer to these kinds of dependencies, since the load
path is under the user's control and can be customized in ways that could
cause these tests to not run correctly.

Signed-off-by: Chris Riddoch riddochc@gmail.com
