### PR TITLE
Added few options for better usage with eval

### DIFF
--- a/cmd_getmouselocation.c
+++ b/cmd_getmouselocation.c
@@ -10,13 +10,16 @@ int cmd_getmouselocation(context_t *context) {
   static struct option longopts[] = {
     { "help", no_argument, NULL, 'h' },
     { "shell", no_argument, NULL, 's' },
+    { "prefix", required_argument, NULL, 'p' },
     { 0, 0, 0, 0 },
   };
   static const char *usage = 
-    "Usage: %s [--shell]\n"
-    "--shell     - output shell variables for use with eval\n";
+    "Usage: %s [--shell] [--prefix <STR>]\n"
+    "--shell      - output shell variables for use with eval\n"
+    "--prefix STR - use prefix for shell variables names (max 16 chars) \n";
   int option_index;
   int output_shell = 0;
+  char out_prefix[17] = {'\0'};
 
   while ((c = getopt_long_only(context->argc, context->argv, "+h",
                                longopts, &option_index)) != -1) {
@@ -29,6 +32,10 @@ int cmd_getmouselocation(context_t *context) {
       case 's':
         output_shell = 1;
         break;
+      case 'p':
+        strncpy(out_prefix, optarg, sizeof(out_prefix)-1);
+        out_prefix[ sizeof(out_prefix)-1 ] = '\0'; //just in case
+        break;
       default:
         fprintf(stderr, usage, cmd);
         return EXIT_FAILURE;
@@ -40,10 +47,10 @@ int cmd_getmouselocation(context_t *context) {
   ret = xdo_get_mouse_location2(context->xdo, &x, &y, &screen_num, &window);
 
   if (output_shell) {
-    xdotool_output(context, "X=%d", x);
-    xdotool_output(context, "Y=%d", y);
-    xdotool_output(context, "SCREEN=%d", screen_num);
-    xdotool_output(context, "WINDOW=%d", window);
+    xdotool_output(context, "%sX=%d", out_prefix, x);
+    xdotool_output(context, "%sY=%d", out_prefix, y);
+    xdotool_output(context, "%sSCREEN=%d", out_prefix, screen_num);
+    xdotool_output(context, "%sWINDOW=%d", out_prefix, window);
   } else {
     xdotool_output(context, "x:%d y:%d screen:%d window:%ld", x, y, screen_num, window);
   }

--- a/cmd_getwindowgeometry.c
+++ b/cmd_getwindowgeometry.c
@@ -7,15 +7,19 @@ int cmd_getwindowgeometry(context_t *context) {
   unsigned int width, height;
 
   int shell_output = False;
+  char out_prefix[17] = {'\0'};
 
   int c;
   static struct option longopts[] = {
     { "help", no_argument, NULL, 'h' },
     { "shell", no_argument, NULL, 's' },
+    { "prefix", required_argument, NULL, 'p' },
     { 0, 0, 0, 0 },
   };
   static const char *usage = 
-    "Usage: %s [window=%1]\n"
+    "Usage: %s [window=%1] [--shell] [--prefix <STR>]\n"
+    "--shell      - output shell variables for use with eval\n"
+    "--prefix STR - use prefix for shell variables names (max 16 chars) \n"
     HELP_SEE_WINDOW_STACK;
   int option_index;
 
@@ -29,6 +33,10 @@ int cmd_getwindowgeometry(context_t *context) {
         break;
       case 's':
         shell_output = True;
+        break;
+      case 'p':
+        strncpy(out_prefix, optarg, sizeof(out_prefix)-1);
+        out_prefix[ sizeof(out_prefix)-1 ] = '\0'; //just in case
         break;
       default:
         fprintf(stderr, usage, cmd);
@@ -57,12 +65,12 @@ int cmd_getwindowgeometry(context_t *context) {
     }
 
     if (shell_output) {
-      xdotool_output(context, "WINDOW=%ld", window);
-      xdotool_output(context, "X=%d", x);
-      xdotool_output(context, "Y=%d", y);
-      xdotool_output(context, "WIDTH=%u", width);
-      xdotool_output(context, "HEIGHT=%u", height);
-      xdotool_output(context, "SCREEN=%d", XScreenNumberOfScreen(screen));
+      xdotool_output(context, "%sWINDOW=%ld", out_prefix, window);
+      xdotool_output(context, "%sX=%d", out_prefix, x);
+      xdotool_output(context, "%sY=%d", out_prefix, y);
+      xdotool_output(context, "%sWIDTH=%u", out_prefix, width);
+      xdotool_output(context, "%sHEIGHT=%u", out_prefix, height);
+      xdotool_output(context, "%sSCREEN=%d", out_prefix, XScreenNumberOfScreen(screen));
     } else {
       xdotool_output(context, "Window %ld", window);
       xdotool_output(context, "  Position: %d,%d (screen: %d)", x, y,

--- a/xdo_cmd.h
+++ b/xdo_cmd.h
@@ -10,6 +10,7 @@
 #include <getopt.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 #include "xdo.h"
 #include "xdotool.h"
 


### PR DESCRIPTION
Added options are:
- `--shell` (for `search` command) exports array of found windows to `WINDOWS=(...)` array.
When this option is used no error is being returned - eval ignores return value anyway and this allows for better command chaining - returning multiple searches with multiple arrays

- `--prefix <STR>` (for commands accepting `--shell` option) adds prefix to shell variable names being printed out.
This allows to:
  - prevent error which manifests when both `getwindogeometry` and `getmouselocation` are used and shell variables are overwritten by each command
  - chain `search` commands to return different `STRWINDOWS` array for each search

Example usage for testing if mouse is inside currently active window of kwrite or konsole:
```bash
eval $( xdotool getwindowfocus getwindowgeometry --shell --prefix W_ \
                getmouselocation --shell --prefix M_ \
                search --shell --prefix KONSOLE_ --onlyvisible --class konsole \
                search --shell --prefix KWRITE_ --onlyvisible --class kwrite )
KONSOLE_WIN=NO
KWRITE_WIN=NO
#trick for quick seraching inside array:
case "${KONSOLE_WINDOWS[@]}" in  *"$M_WINDOW"*) KONSOLE_WIN=YES ;; esac
case "${KWRITE_WINDOWS[@]}" in  *"$M_WINDOW"*) KWRITE_WIN=YES ;; esac

if [[ $M_WINDOW == $W_WINDOW ]]
then
  echo "Inside KWRITE? $KWRITE_WIN"
  echo "Inside KONSOLE? $KONSOLE_WIN"
fi
```