### PR TITLE
Fixed issue #48.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ CFLAGS?=-pipe -O2 $(WARNFLAGS)
 CFLAGS+=-g # TODO(sissel): Comment before release
 CFLAGS+=$(CPPFLAGS)
 
-DEFAULT_LIBS=-L/usr/X11R6/lib -L/usr/local/lib -lX11 -lXtst -lXinerama
+DEFAULT_LIBS=-L/usr/X11R6/lib -L/usr/local/lib -lX11 -lXtst -lXinerama -lxkbcommon
 DEFAULT_INC=-I/usr/X11R6/include -I/usr/local/include
 
 XDOTOOL_LIBS=$(shell pkg-config --libs x11 2> /dev/null || echo "$(DEFAULT_LIBS)")  $(shell sh platform.sh extralibs)

--- a/xdotool.pod
+++ b/xdotool.pod
@@ -66,7 +66,7 @@ are valid keystrokes.
 Example: Send the keystroke "F2"
  xdotool key F2
 
-Example: Send 'a' with an accent over it (not on english keyboards, but still
+Example: Send 'a' with an accent over it (not on English keyboards, but still
 works with xdotool)
  xdotool key Aacute
 
@@ -442,7 +442,7 @@ World"
 =item B<--sync >
 
 Block until there are results. This is useful when you are launching an
-application want want to wait until the application window is visible.
+application and want to wait until the application window is visible.
 For example:
 
  google-chrome &
@@ -1056,7 +1056,7 @@ These would error:
 
 When xdotool exits, the current window stack is lost.
 
-Additinally, commands that modify the L<WINDOW STACK> will not print the
+Additionally, commands that modify the L<WINDOW STACK> will not print the
 results if they are not the last command. For example:
 
  # Output the active window:


### PR DESCRIPTION
Now xdotool target can be compiled on systems which don't have pkg-config installed.

At Makefile:274, it falled back to DEFAULT_LIBS if pkg-config wasn't present. However DEFAULT_LIBS didn't contain a reference to link xkbcommon library, so the compilation process failed.