### PR TITLE
Added windowlower command to match windowraise

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ CMDOBJS= cmd_click.o cmd_mousemove.o cmd_mousemove_relative.o cmd_mousedown.o \
          cmd_windowraise.o cmd_windowsize.o cmd_set_window.o cmd_search.o \
          cmd_getwindowfocus.o cmd_getwindowpid.o cmd_getactivewindow.o \
          cmd_windowmap.o cmd_windowunmap.o cmd_windowreparent.o \
-         cmd_set_num_desktops.o \
+         cmd_set_num_desktops.o cmd_windowlower.o \
          cmd_get_num_desktops.o cmd_set_desktop.o cmd_get_desktop.o \
          cmd_set_desktop_for_window.o cmd_get_desktop_for_window.o \
          cmd_get_desktop_viewport.o cmd_set_desktop_viewport.o \
@@ -271,4 +271,3 @@ $(DEBDIR)/libxdo$(MAJOR)-dev/data.tar.gz: $(DEBDIR)/libxdo$(MAJOR)-dev/
 # Build a tarball for xdotool-doc files
 $(DEBDIR)/xdotool-doc/data.tar.gz: $(DEBDIR)/xdotool-doc/
 	tar -C $(DEBDIR) -zcf $@ usr/share
-

--- a/cmd_windowlower.c
+++ b/cmd_windowlower.c
@@ -1,0 +1,49 @@
+#include "xdo_cmd.h"
+
+int cmd_windowlower(context_t *context) {
+  int ret = 0;
+  char *cmd = *context->argv;
+  const char *window_arg = "%1";
+
+  int c;
+  static struct option longopts[] = {
+    { "help", no_argument, NULL, 'h' },
+    { 0, 0, 0, 0 },
+  };
+  static const char *usage = 
+    "Usage: %s [window=%1]\n"
+    HELP_SEE_WINDOW_STACK;
+  int option_index;
+
+  while ((c = getopt_long_only(context->argc, context->argv, "+h",
+                               longopts, &option_index)) != -1) {
+    switch (c) {
+      case 'h':
+        printf(usage, cmd);
+        consume_args(context, context->argc);
+        return EXIT_SUCCESS;
+        break;
+      default:
+        fprintf(stderr, usage, cmd);
+        return EXIT_FAILURE;
+    }
+  }
+
+  consume_args(context, optind);
+
+  if (!window_get_arg(context, 0, 0, &window_arg)) {
+    fprintf(stderr, usage, cmd);
+    return EXIT_FAILURE;
+  }
+
+  window_each(context, window_arg, {
+    ret = xdo_lower_window(context->xdo, window);
+    if (ret) {
+      fprintf(stderr, "xdo_lower_window reported an error on window %ld\n",
+              window);
+    }
+  }); /* window_each(...) */
+
+  return ret;
+} /* int cmd_windowlower(context_t *) */
+

--- a/examples/toggle-app.sh
+++ b/examples/toggle-app.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Toggle an application - launches, focuses, or lowers an X application.  Tests in findWindow are heuristic, based on
+# making it work for Geany, Chrome, Nautilus, gnome calculator gnome charmap, gnome terminal, and terminator. 
+# Very useful bound to a keyboard shortcut.
+# 
+# Usage: 
+#     toggle-app.sh WM_CLASS command args
+
+function findWindow() {
+	echo "Searching for $1" >&2
+	for id in `xdotool search --class "$1"`; do
+		echo "ID: $id" >&2
+		TMP=`tempfile`
+		xprop -id $id > $TMP
+		echo "${PROP[@]}"
+		test -n "$(cat $TMP | grep 'WM_STATE' | grep -v 'WM_STATE_SKIP')"; SKIP=$?
+		#echo "noskip: ${SKIP}" >&2
+		#if [[ $NOSKIP -eq 1 ]]; then
+		#	cat $TMP | grep 'WM_STATE' >&2
+		#	cat $TMP | grep 'WM_STATE'  | grep -v 'WM_STATE_SKIP' >&2
+		#fi
+		test -z "$(cat $TMP | grep 'WM_WINDOW_ROLE')" -o -z "$(echo ${PROP[@]} | grep 'WM_WINDOW_ROLE' | grep -v '"pop-up"')"; NOPOPUP=$?
+		echo "popup: ${NOPOPUP}" >&2
+		test -n "$(cat $TMP | grep 'WM_ALLOWED_ACTIONS' | grep 'WM_ACTION_MOVE')"; MOVEALLOWED=$?
+		echo "immovable: ${MOVEALLOWED}" >&2
+		test -n "$(cat $TMP | grep 'WM_NORMAL_HINTS')"; HASHINTS=$?
+		rm $TMP
+		echo "unhinted: ${HASHINTS}" >&2
+		if [[ $NOPOPUP -eq 0 && $MOVEALLOWED -eq 0 && $HASHINTS -eq 0 ]]; then
+			echo $id;
+		else
+			echo "$id does not meet requirements" >&2
+		fi
+	done
+}
+
+WM_CLASS=$1; shift
+CMD=$1; shift
+WM_ID=`findWindow $WM_CLASS | tail -1`
+WM_PID=`xdotool getwindowpid $WM_ID`
+ACTIVE_WM_ID=`xdotool getactivewindow`
+ACTIVE_WM_PID=`xdotool getwindowpid $ACTIVE_WM_ID`
+echo "Active window is ${ACTIVE_WM_ID} (${ACTIVE_WM_PID})"
+if [[ -z "$WM_ID" ]]; then
+	echo "No matching window id for class $WM_CLASS; running " ${CMD} "$@"
+	setsid $CMD "$@" > /dev/null 2>&1 & disown $!
+else
+	echo "Found ID: ${WM_ID}"
+	if [[ "$WM_ID" == "$ACTIVE_WM_ID" ]]; then
+		echo "Lowering."
+		xdotool windowlower $WM_ID
+	else
+		echo "Raising."
+		xdotool windowactivate $WM_ID
+	fi
+fi

--- a/t/test_basic.rb
+++ b/t/test_basic.rb
@@ -35,6 +35,17 @@ class XdotoolBasicTests < Test::Unit::TestCase
     assert_status_fail(status)
   end
 
+  def test_windowlower_succeeds_on_valid_window
+    status, lines = xdotool "windowlower #{@wid}"
+    assert_status_ok(status)
+    assert_equal(0, lines.length, "No output from windowlower")
+  end
+
+  def test_windowlower_fails_on_invalid_window
+    status, lines = xdotool "windowlower 1 2> /dev/null"
+    assert_status_fail(status)
+  end
+
   def test_windowsize_by_pixel_works
     w = 500
     h = 400
@@ -216,4 +227,3 @@ class XdotoolBasicTests < Test::Unit::TestCase
     end
   end
 end
-

--- a/xdo.c
+++ b/xdo.c
@@ -761,6 +761,13 @@ int xdo_raise_window(const xdo_t *xdo, Window wid) {
   return _is_success("XRaiseWindow", ret == 0, xdo);
 }
 
+int xdo_lower_window(const xdo_t *xdo, Window wid) {
+  int ret = 0;
+  ret = XLowerWindow(xdo->xdpy, wid);
+  XFlush(xdo->xdpy);
+  return _is_success("XLowerWindow", ret == 0, xdo);
+}
+
 int xdo_move_mouse(const xdo_t *xdo, int x, int y, int screen)  {
   int ret = 0;
 

--- a/xdo.h
+++ b/xdo.h
@@ -534,6 +534,14 @@ int xdo_focus_window(const xdo_t *xdo, Window wid);
 int xdo_raise_window(const xdo_t *xdo, Window wid);
 
 /**
+ * Lower a window to the bottom of the window stack. This is also sometimes
+ * termed as sending the window back.
+ *
+ * @param wid The window to raise.
+ */
+int xdo_lower_window(const xdo_t *xdo, Window wid);
+
+/**
  * Get the window currently having focus.
  *
  * @param window_ret Pointer to a window where the currently-focused window

--- a/xdotool.c
+++ b/xdotool.c
@@ -251,6 +251,7 @@ struct dispatch {
   { "windowfocus", cmd_windowfocus, },
   { "windowkill", cmd_windowkill, },
   { "windowclose", cmd_windowclose, },
+  { "windowlower", cmd_windowlower, },
   { "windowmap", cmd_windowmap, },
   { "windowminimize", cmd_windowminimize, },
   { "windowmove", cmd_windowmove, },

--- a/xdotool.h
+++ b/xdotool.h
@@ -70,6 +70,7 @@ int cmd_windowmap(context_t *context);
 int cmd_windowminimize(context_t *context);
 int cmd_windowmove(context_t *context);
 int cmd_windowraise(context_t *context);
+int cmd_windowlower(context_t *context);
 int cmd_windowreparent(context_t *context);
 int cmd_windowsize(context_t *context);
 int cmd_windowunmap(context_t *context);

--- a/xdotool.pod
+++ b/xdotool.pod
@@ -668,6 +668,12 @@ before moving on.
 
 =back
 
+=item B<windowlower> I<[window_id=%1]>
+
+Lower the window to the bottom of the stack. This may not work on all window
+managers. If no window is given, %1 is the default. See L<WINDOW STACK> and
+L<COMMAND CHAINING> for more details.
+
 =item B<windowraise> I<[window_id=%1]>
 
 Raise the window to the top of the stack. This may not work on all window


### PR DESCRIPTION
I needed it for a personal script - toggle-app.sh, added in examples.  Take or leave that; I'm really unhappy with the heuristic tests in findWindow.  For an example, it's fine.  For production it's a mess.  Maybe later I'll work on adding clauses to `xdotool search` for window flags - but that can be a crazy complex endeavor in dynamic and OO languages, let alone a static, non-OO lang.

Sorry about the EOF newline trims.  Something's wrong with my configuration for Meld, I think, that it's not catching that stuff - even though I validate my changes prior to commit, I couldn't see it until I started the pull request.  Checking now, Meld isn't reporting anything's wrong.   Compile went fine though, and the tests ran normally - I guess "no newline at EOF" isn't an error in C anymore?  It's been a while.
