### PR TITLE
Makefile: allow to override the ldconfig command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ INSTALLBIN?=$(PREFIX)/bin
 INSTALLLIB?=$(PREFIX)/lib
 INSTALLMAN?=$(PREFIX)/man
 INSTALLINCLUDE?=$(PREFIX)/include
+LDCONFIG?=ldconfig
 
 DPREFIX=$(DESTDIR)$(PREFIX)
 DINSTALLBIN=$(DESTDIR)$(INSTALLBIN)
@@ -77,7 +78,7 @@ pre-install:
 post-install:
 	@if [ "$$(uname)" = "Linux" ] ; then \
 		echo "Running ldconfig to update library cache"; \
-		ldconfig \
+		$(LDCONFIG) \
 		  || echo "Failed running 'ldconfig'. Maybe you need to be root?"; \
 	fi
 


### PR DESCRIPTION
When cross-compiling, calling ldconfig at build time doesn't make
sense (since it would run ldconfig on the build machine, which is
irrelevant when cross-compiling). In order to avoid calling ldconfig
in such situations, this patch introduces a LDCONFIG make variable,
which defaults to 'ldconfig', but can be overridden if needed with
'/bin/true' for people who would like to skip the ldconfig step.

This way, the behavior is unchanged for normal users, and users
willing to do cross-compilation can do 'make LDCONFIG=/bin/true
install'.

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>