### PR TITLE
Fix 'xdotool click --clearmodifiers 2'.

### DIFF
--- a/xdo.c
+++ b/xdo.c
@@ -940,9 +940,10 @@ int xdo_click_window_multiple(const xdo_t *xdo, Window window, int button,
       return ret;
     }
     repeat--;
-    if (repeat > 0) {
-      usleep(delay);
-    }
+
+    /* Sleeping even after the last click is important, so that a call to xdo_set_active_modifiers()
+     * right after won't think that the button is still pressed. */
+    usleep(delay);
   } /* while (repeat > 0) */
   return ret;
 } /* int xdo_click_window_multiple */


### PR DESCRIPTION
**Issue:**

`xdotool click --clearmodifiers 2` leaves the middle mouse button pressed. This can easily be seen with [xev](http://www.x.org/archive/X11R7.7/doc/man/man1/xev.1.xhtml) or with Chrome: after running the command, (left) clicking on a browser tab will close it, as it will be wrongly interpreted as a middle mouse click. 

Expected result: this command should perform a middle mouse click (works) and leaves the middle mouse button released afterwards (broken).

This happens only with `--clearmodifiers`. `--delay` doesn't help.

**What happens:**

Right after the click is performed by `xdo_click_window_multiple()`, `xdo_set_active_modifiers()` calls `xdo_get_input_state()` (**too early**) in order to determine what mouse buttons are pressed, in order to restore them after having restored the modifiers. It then thinks that the middle button is still pressed on purpose and re-presses it after having restored the modifiers.

**Fix:**

Apply the normal delay after having performed the click.

Click-related unit tests (`test_basic.rb` and `test_chaining.rb`) are still passing.