### PR TITLE
gitignore 'libxdo.so.3' and 'xdotool'.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.o
-*.so
+*.so*
 *.1
 xdo_version.h
+xdotool


### PR DESCRIPTION
`libxdo.so.3` and `xdotool` are produced by `make` on Ubuntu 14.04.