### PR TITLE
Makefile change: DEB package should have control.tar.gz before data.t…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -232,7 +232,7 @@ create-package-deb: pre-create-package VERSION xdo_version.h
 	wd=$$PWD; \
 	cd $(DEBDIR)/$*; \
 	  ar -qc $$wd/$*_$(VERSION)-1_$(shell uname -m).deb \
-	    debian-binary data.tar.gz control.tar.gz
+	    debian-binary control.tar.gz data.tar.gz
 
 $(DEBDIR)/usr:
 	$(MAKE) install DESTDIR=$(DEBDIR) PREFIX=/usr INSTALLMAN=/usr/share/man


### PR DESCRIPTION
…ar.gz

Without this change, the DEB package is built successfully, but fails on install using 'dpkg -i'