### PR TITLE
Bugfix: fix logic to find unused keycode

### DIFF
--- a/xdo.c
+++ b/xdo.c
@@ -1028,9 +1028,10 @@ int xdo_send_keysequence_window_list_do(const xdo_t *xdo, Window window, charcod
   KeySym *keysyms = NULL;
   int keysyms_per_keycode = 0;
   int scratch_keycode = 0; /* Scratch space for temporary keycode bindings */
-  //keysyms = XGetKeyboardMapping(xdo->xdpy, xdo->keycode_low, 
-                                //xdo->keycode_high - xdo->keycode_low,
-                                //&keysyms_per_keycode);
+  keysyms = XGetKeyboardMapping(xdo->xdpy, xdo->keycode_low,
+                                xdo->keycode_high - xdo->keycode_low,
+                                &keysyms_per_keycode);
+
   /* Find a keycode that is unused for scratchspace */
   for (i = xdo->keycode_low; i <= xdo->keycode_high; i++) {
     int j = 0;


### PR DESCRIPTION
Use XGetKeyboardMapping to get a list of keysyms for keycodes that can be used
to find unused keycodes. The code previously assumed a list of keysyms was
being fetched like this but it wasn't.

Fixes an issue where xdotool would clobber the lowest keycode.

fixes #129