### PR TITLE
Responsive pipe

### DIFF
--- a/xdotool.c
+++ b/xdotool.c
@@ -475,6 +475,15 @@ int script_main(int argc, char **argv) {
       context.argv = script_argv;
       result = context_execute(&context);
 
+      /*
+       * Free the allocated memory for tokens.
+       */
+      for(int j = 0; j < script_argc; j++){
+        if(*(script_argv + j) != NULL){
+          free(*(script_argv + j));
+        }
+      }
+
       script_argc = 0;
       *script_argv = NULL;
     }


### PR DESCRIPTION
When xdotool commands were read from pipe, they were executed only when the pipe was closed, thus if external process wanted to make more than one call to xdotool it had to create new process per each call as a result spending more system resources than could be spent. Other drawback with that approach is that xdotool can read from pipe as many commands as it can address in RAM in one run.

This fixes both of those issues. Each command from pipe is executed exactly after the newline is reached and all tokens in that line are parsed.

Dynamic memory is allocated only as much as the longest token-line requires, plus each size of each token. This is not the most efficient approach, but it is simple and in overall for this use-case should be fine.

Most of the parsing algorithm ideas were taken from the existing code, thus there should be no implications of the way xdotool functions with pipes. The only thing that i can think of now is that in the old algorithm all tokens were arranged in one huge token queue when reading from pipe, now pipe is parsed/executed line by line, thus commands must have all the required arguments in the same line. I don't see a reason why should it be otherwise, but to mention an implication, i state it here.

Other thing which i don't not know to handle correctly is a TODO comment after "script_argv = realloc(script_argv, (script_argc+1) * sizeof(char *));" line in function script_main. What this TODO was meant for? The only thing there i could see as a little bug was that when memory was reallocated, the expected NULL pointer was not added at the end. AFAIK newly allocated portion by realloc is indeterminate, thus there was no guarantee that the token list would end with NULL.

