### PR TITLE
Makefile: fix rpath fix on Darwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ libxdo.$(VERLIBSUFFIX): libxdo.$(LIBSUFFIX)
 # TODO(sissel): only do this linker hack if we're using GCC?
 xdotool: LDFLAGS+=-Xlinker
 ifneq ($(WITHOUT_RPATH_FIX),1)
-xdotool: LDFLAGS+=-rpath=$(INSTALLLIB)
+xdotool: LDFLAGS+=-rpath $(INSTALLLIB)
 endif
 xdotool: xdotool.o $(CMDOBJS) libxdo.$(LIBSUFFIX)
 	$(CC) -o $@ xdotool.o $(CMDOBJS) -L. -lxdo $(LDFLAGS)  -lm $(XDOTOOL_LIBS)


### PR DESCRIPTION
The flag doesn't actually seem to be necessary, but this invocation doesn't cause any errors either.

refs #138.