### PR TITLE
Makefile: fix LIBXDL_LIBS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ DEFAULT_LIBS=-L/usr/X11R6/lib -L/usr/local/lib -lX11 -lXtst -lXinerama -lxkbcomm
 DEFAULT_INC=-I/usr/X11R6/include -I/usr/local/include
 
 XDOTOOL_LIBS=$(shell pkg-config --libs x11 2> /dev/null || echo "$(DEFAULT_LIBS)")  $(shell sh platform.sh extralibs)
-LIBXDO_LIBS=$(shell pkg-config --libs xtst xinerama xkbcommon 2> /dev/null || echo "$(DEFAULT_LIBS)")
+LIBXDO_LIBS=$(shell pkg-config --libs x11 xtst xinerama xkbcommon 2> /dev/null || echo "$(DEFAULT_LIBS)")
 INC=$(shell pkg-config --cflags x11 xtst xinerama xkbcommon 2> /dev/null || echo "$(DEFAULT_INC)")
 CFLAGS+=-std=c99 $(INC)
 


### PR DESCRIPTION
The cflags included x11, but ldflags didn’t.

refs #138 