### PR TITLE
Added escaping capability within quoted parametters for input.

### DIFF
--- a/xdotool.c
+++ b/xdotool.c
@@ -317,6 +317,66 @@ int xdotool_main(int argc, char **argv) {
   return args_main(argc, argv);
 }
 
+/*
+ * @DESCRIPTION:
+ *   Function that null-terminates and unescapes quoted tag. When value is
+ *   unescaped remaining memory buffer's ptr_buf content is moved to beginning.
+ * @PARAMS:
+ *   ptr - pointer to string buffer where to null-terminate tag. It must start
+ *         with quote.
+ * @RETURN:
+ *   returns pointer to tag start within ptr buffer; continious buffer content
+ *   remains after null character so buffer size must be known from the calling
+ *   code.
+ */
+char *null_terminate_quoted(char *ptr_buf);
+char *null_terminate_quoted(char *ptr_buf){
+  size_t len;
+  char *ptr_quote;
+  char needle[3] = "'\\";
+  /* flag for state - if memory buffer contents should be moved */
+  char flg_move;
+
+  ptr_quote = ptr_buf + 1;
+  *needle = *ptr_buf;
+
+  while(*ptr_quote){
+    ptr_quote += strcspn(ptr_quote, needle);
+    /* closing string found */
+    if(*ptr_quote == *ptr_buf){
+      *ptr_quote = 0;
+    }
+    /* escaping slash found */
+    else{
+      flg_move = 0;
+      switch(*(ptr_quote + 1)){
+        /* Nothing to be done for slash, because it is the same anyways. */
+        case '\\':
+          flg_move = 1;
+          break;
+        /* Escaped quotes become quotes */
+        case '\'':
+        case '"':
+          *ptr_quote = *(ptr_quote + 1);
+          flg_move = 1;
+          break;
+        /* Here could add more single byte escape sequences if necessary. */
+      }
+
+      if(flg_move){
+        len = strlen(ptr_quote);
+        memmove(ptr_quote, ptr_quote + 1, strlen(ptr_quote));
+        /* Because escaping character is moved, buffer becomes shorter. */
+        *(ptr_quote + len - 1) = 0;
+        /* Because escaped char was handled by case statement */
+        ptr_quote++;
+      }
+    }
+  }
+
+  return ++ptr_buf;
+}
+
 int script_main(int argc, char **argv) {
   /* Tokenize the input file while expanding positional parameters and
    * environment variables. Pass the resulting argument list to
@@ -385,12 +445,10 @@ int script_main(int argc, char **argv) {
        * separated by whitespace, or quoted with single/double quotes.
        */
       if (line[0] == '"') {
-        line++;
-        line[strcspn(line, "\"")] = '\0';
+        line = null_terminate_quoted(line);
       }
       else if (line[0] == '\'') {
-        line++;
-        line[strcspn(line, "\'")] = '\0';
+        line = null_terminate_quoted(line);
       }
       else {
         line[strcspn(line, " \t")] = '\0';
@@ -450,7 +508,7 @@ int script_main(int argc, char **argv) {
         }
         script_argv[script_argc] = (char *) calloc(strlen(token) + 1, sizeof(char));
 
-        //printf("arg %d: %s\n", script_argc, token);
+        // printf("arg %d: %s\n", script_argc, token);
         strncpy(script_argv[script_argc], token, strlen(token)+1);      
         script_argc++;
       }

--- a/xdotool.c
+++ b/xdotool.c
@@ -346,6 +346,15 @@ char *null_terminate_quoted(char *ptr_buf){
     if(*ptr_quote == *ptr_buf){
       *ptr_quote = 0;
     }
+    else if(*ptr_quote == 0){
+      /* 
+       * We don't have pre-parsing state nowhere, so it is not possible to give
+       * more detailed error.
+       */
+      fprintf(stderr, "WARNING: Quote not closed within parsed script. " 
+        "Resulting argument is: `%s`.\n", ptr_buf
+      );
+    }
     /* escaping slash found */
     else{
       flg_move = 0;


### PR DESCRIPTION
When input was read from pipe or file, quoted parameters could not contain quotes themselves and there was no way to escape them. For example if command 'search' should find a window that is named <Some text "that's good" >, it was not possible to do unless changing some of quotes with regex dot to match them.

With this upgrade it is possible to escape quotes with backslash just like in most commonly used programming languages, for example, search "Some text \"that's good\"" or search 'Some text "that\'s good"'.

Now escaping works with both types of quotes. Philosophical question though remains whether escapes should work in both types of quotes. There are languages which allow only to escape single quote and backslash only when using single quotes and extended escapes when using double quotes. At the moment since extended escaping is not implemented it maybe does not matter that much and for simplicity same functionality was implemented for both quote types. But maybe if we decide that now, could add comment in code for future.

Theoretically this upgrade should not influence previous functionality anyhow, since quote closing is handled almost the same way as previously.

It was tested only with search command, but it could be possible that other commands could benefit from this upgrade too. It was not tested with newline, tab and similar regex special escapes, but it should work as well, because those are just passed through unchanged.
