### PR TITLE
Extend "seach --sync" command with timing tunables.

### DIFF
--- a/cmd_search.c
+++ b/cmd_search.c
@@ -215,12 +215,12 @@ int cmd_search(context_t *context) {
     if (op_sync && nwindows == 0) {
       xdotool_debug(context, "No search results, still waiting...");
 
-      usleep(sync_duration_usec);
       if(sync_max_iter){
         if(++sync_iter >= sync_max_iter){
           break;
         }
       }
+      usleep(sync_duration_usec);
     }
   } while (op_sync && nwindows == 0);
 

--- a/xdotool.pod
+++ b/xdotool.pod
@@ -439,11 +439,20 @@ default. For example:
 This will match any windows owned by pid 1424 or windows with name "Hello
 World"
 
-=item B<--sync >
+=item B<--sync [T [A]]>
 
-Block until there are results. This is useful when you are launching an
-application and want to wait until the application window is visible.
-For example:
+Block infiniteley until there are any results found. Command takes optional 
+parammeters: 
+ T - sync waiting time till next search attempt, default: 0.5
+ A - attempt count, 0 means infinity, default: 0.
+
+In total sync blocking time is T * A seconds until a search command result 
+is resolved.
+
+This is useful when you are launching an application and want to wait for some 
+defined time interval and/or until the application window is found.
+
+For example this makes xdotool to wait infiniteley till application is visible:
 
  google-chrome &
  xdotool search --sync --onlyvisible --class "google-chrome"


### PR DESCRIPTION
This modification extends xdotool "seach --sync" command with execution total time, attempt count and waiting time before next attempt tunables. Unfortunately i need this functionality and TODO was left in code too, thus two rabbits with one shot.

Code should be fine even for future use cases, when there is some non-blocking way of how to seach for windows by these complex criteria until they are found (this seems unlikely to happen, but anyways this change does not disturb that).

I'm not too good in writing comments and manual pages, so maybe some brush-up is needed on that.

Change should not leave any implication on the old scripts, because the default values are the same as values which were used before.
