### PR TITLE
Extend xdotool with getwindowstacklen command.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ CMDOBJS= cmd_click.o cmd_mousemove.o cmd_mousemove_relative.o cmd_mousedown.o \
          cmd_set_desktop_for_window.o cmd_get_desktop_for_window.o \
          cmd_get_desktop_viewport.o cmd_set_desktop_viewport.o \
          cmd_windowkill.o cmd_behave.o cmd_window_select.o \
-         cmd_getwindowname.o cmd_behave_screen_edge.o \
+         cmd_getwindowname.o cmd_getwindowstacklen.o cmd_behave_screen_edge.o \
          cmd_windowminimize.o cmd_exec.o cmd_getwindowgeometry.o \
          cmd_windowclose.o \
          cmd_sleep.o cmd_get_display_geometry.o

--- a/cmd_getwindowstacklen.c
+++ b/cmd_getwindowstacklen.c
@@ -1,0 +1,36 @@
+#include "xdo_cmd.h"
+
+int cmd_getwindowstacklen(context_t *context) {
+  char *cmd = context->argv[0];
+
+  int c;
+  static struct option longopts[] = {
+    { "help", no_argument, NULL, 'h' },
+    { 0, 0, 0, 0 },
+  };
+  static const char *usage = 
+    "Usage: %s \n"
+    HELP_SEE_WINDOW_STACK;
+  int option_index;
+
+  while ((c = getopt_long_only(context->argc, context->argv, "+h",
+                               longopts, &option_index)) != -1) {
+    switch (c) {
+      case 'h':
+        printf(usage, cmd);
+        consume_args(context, context->argc);
+        return EXIT_SUCCESS;
+        break;
+      default:
+        fprintf(stderr, usage, cmd);
+        return EXIT_FAILURE;
+    }
+  }
+
+
+  consume_args(context, optind);
+  xdotool_output(context, "stack_length:%i", context->nwindows);
+
+  return EXIT_SUCCESS;
+}
+

--- a/cmd_getwindowstacklen.c
+++ b/cmd_getwindowstacklen.c
@@ -31,6 +31,6 @@ int cmd_getwindowstacklen(context_t *context) {
   consume_args(context, optind);
   xdotool_output(context, "stack_length:%i", context->nwindows);
 
-  return EXIT_SUCCESS;
+  return context->nwindows? EXIT_SUCCESS : EXIT_FAILURE;
 }
 

--- a/cmd_search.c
+++ b/cmd_search.c
@@ -70,6 +70,7 @@ int cmd_search(context_t *context) {
 
   char *cmd = *context->argv;
   int option_index;
+  char flg_keep_chain = 0;
 
   while ((c = getopt_long_only(context->argc, context->argv, "+h",
                                longopts, &option_index)) != -1) {
@@ -139,6 +140,12 @@ int cmd_search(context_t *context) {
     }
   }
 
+  /*
+   * Look-ahead if next command can work with empty window stack or not.
+   */
+  if(strcasecmp(*(context->argv + optind + 1), "getwindowstacklen") == 0){
+    flg_keep_chain = 1;
+  }
   consume_args(context, optind);
 
   /* We require a pattern or a pid to search for */
@@ -205,6 +212,10 @@ int cmd_search(context_t *context) {
   }
   context->windows = list;
   context->nwindows = nwindows;
+
+  if(flg_keep_chain){
+    return EXIT_SUCCESS;
+  }
 
   /* error if number of windows found is zero (behave like grep) 
   but return success when being used inside eval (--shell option)*/

--- a/cmd_search.c
+++ b/cmd_search.c
@@ -143,8 +143,12 @@ int cmd_search(context_t *context) {
   /*
    * Look-ahead if next command can work with empty window stack or not.
    */
-  if(strcasecmp(*(context->argv + optind + 1), "getwindowstacklen") == 0){
-    flg_keep_chain = 1;
+  if(context->argc > optind + 1){
+    if(*(context->argv + optind + 1)){
+      if(strcasecmp(*(context->argv + optind + 1), "getwindowstacklen") == 0){
+        flg_keep_chain = 1;
+      }
+    }
   }
   consume_args(context, optind);
 

--- a/cmd_search.c
+++ b/cmd_search.c
@@ -15,6 +15,7 @@ int cmd_search(context_t *context) {
   char out_prefix[17] = {'\0'};
   int search_class = 0;
   int search_classname = 0;
+  char flg_keep_chain = 0;
   typedef enum {
     opt_unused, opt_title, opt_onlyvisible, opt_name, opt_shell, opt_prefix, opt_class, opt_maxdepth,
     opt_pid, opt_help, opt_any, opt_all, opt_screen, opt_classname, opt_desktop,
@@ -70,7 +71,6 @@ int cmd_search(context_t *context) {
 
   char *cmd = *context->argv;
   int option_index;
-  char flg_keep_chain = 0;
 
   while ((c = getopt_long_only(context->argc, context->argv, "+h",
                                longopts, &option_index)) != -1) {

--- a/xdotool.c
+++ b/xdotool.c
@@ -225,6 +225,7 @@ struct dispatch {
   { "getwindowname", cmd_getwindowname, },
   { "getwindowpid", cmd_getwindowpid, },
   { "getwindowgeometry", cmd_getwindowgeometry, },
+  { "getwindowstacklen", cmd_getwindowstacklen, },
   { "getdisplaygeometry", cmd_get_display_geometry, },
   { "search", cmd_search, },
   { "selectwindow", cmd_window_select, },

--- a/xdotool.h
+++ b/xdotool.h
@@ -51,6 +51,7 @@ int cmd_getwindowfocus(context_t *context);
 int cmd_getwindowname(context_t *context);
 int cmd_getwindowpid(context_t *context);
 int cmd_getwindowgeometry(context_t *context);
+int cmd_getwindowstacklen(context_t *context);
 int cmd_help(context_t *context);
 int cmd_key(context_t *context);
 int cmd_mousedown(context_t *context);

--- a/xdotool.pod
+++ b/xdotool.pod
@@ -539,6 +539,10 @@ Output values suitable for 'eval' in a shell.
 
 =back
 
+=item B<getwindowstacklen>
+
+Output the length of window stack. See L<WINDOW STACK> for more details.
+
 =item B<getwindowfocus> [-f]
 
 Prints the window id of the currently focused window. Saves the result to the


### PR DESCRIPTION
When running xdotool search command without closing any pipe, it was not possible to anyhow determine if search command finished without any results, since it does not print any character. The only workaround was to use getmouselocation, but it is only a workaround. 

Command returns output in similar fashion as getmouselocation, for example:
stack_length:123

This is a cleaner way to count of how many windows have been matched by search parameters. Even if used in bash scripts when pipe is closed and output lines counted.
