### PR TITLE
Fixed 'type' --window to use default %1 as manpage stated

### DIFF
--- a/cmd_key.c
+++ b/cmd_key.c
@@ -47,8 +47,8 @@ int cmd_key(context_t *context) {
      "including those not currently available on your keyboard.\n"
      "\n"
      "If no window is given, and there are windows in the stack, %1 is used. Otherwise\n"
-     "the currently-focused window is used\n"
-     HELP_CHAINING_ENDS;
+     "the currently-focused window is used\n";
+
   int option_index;
 
   while ((c = getopt_long_only(context->argc, context->argv, "+d:hcw:",

--- a/cmd_type.c
+++ b/cmd_type.c
@@ -8,7 +8,7 @@ int cmd_type(context_t *context) {
   int i;
   int c;
   char *cmd = *context->argv;
-  char *window_arg = NULL;
+  const char *window_arg = "%1";
   int arity = -1;
   char *terminator = NULL;
   char *file = NULL;
@@ -59,14 +59,15 @@ int cmd_type(context_t *context) {
     "--file <filepath> - specify a file, the contents of which will be\n"
     "                    be typed as if passed as an argument. The filepath\n"
     "                    may also be '-' to read from stdin.\n"
-            "-h, --help             - show this help output\n";
+            "-h, --help             - show this help output\n"
+    HELP_SEE_WINDOW_STACK;
   int option_index;
 
   while ((c = getopt_long_only(context->argc, context->argv, "+w:d:ch",
                                longopts, &option_index)) != -1) {
     switch (c) {
       case opt_window:
-        window_arg = strdup(optarg);
+        window_arg = optarg;
         break;
       case opt_delay:
         /* --delay is in milliseconds, convert to microseconds */
@@ -202,10 +203,6 @@ int cmd_type(context_t *context) {
   }); /* window_each(...) */
 
   free(data);
-
-  if (window_arg != NULL) {
-    free(window_arg);
-  }
 
   consume_args(context, args_count);
   return ret > 0;


### PR DESCRIPTION
Fixed 'type' --window to use default %1 as manpage stated
Fixed 'key' usage to remove END_CHAINING because it is possible,
'key' checks if next word is a command.

Closes #145 