### PR TITLE
add windowstate command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ CFLAGS+=-std=c99 $(INC)
 CMDOBJS= cmd_click.o cmd_mousemove.o cmd_mousemove_relative.o cmd_mousedown.o \
          cmd_mouseup.o cmd_getmouselocation.o cmd_type.o cmd_key.o \
          cmd_windowmove.o cmd_windowactivate.o cmd_windowfocus.o \
-         cmd_windowraise.o cmd_windowsize.o cmd_set_window.o cmd_search.o \
+         cmd_windowraise.o cmd_windowsize.o cmd_windowstate.o cmd_set_window.o cmd_search.o \
          cmd_getwindowfocus.o cmd_getwindowpid.o cmd_getactivewindow.o \
          cmd_windowmap.o cmd_windowunmap.o cmd_windowreparent.o \
          cmd_set_num_desktops.o \

--- a/cmd_windowstate.c
+++ b/cmd_windowstate.c
@@ -1,0 +1,109 @@
+#include <ctype.h>
+#include <errno.h>
+#include "xdo_cmd.h"
+
+static char *parse_property(const char *arg_property) {
+  const char *prefix = "_NET_WM_STATE_";
+  const size_t len_prefix = strlen(prefix);
+  char *property;
+  char *pdst;
+  const char *psrc;
+
+  property = (char *) malloc(len_prefix + strlen(arg_property) + 1);
+  if (!property) {
+    return NULL;
+  }
+  strcpy(property, prefix);
+  pdst = property + len_prefix;
+  psrc = arg_property;
+  while (*psrc) {
+    *pdst++ = (char) toupper((int) *psrc++);
+  }
+  *pdst = 0;
+  return property;
+}
+
+int cmd_windowstate(context_t *context) {
+  int ret = 0;
+  int has_error = 0;
+
+  char *cmd = *context->argv;
+  int c;
+  const char *window_arg = "%1";
+
+  unsigned long action = (unsigned long) -1;
+  const char *arg_property = NULL;
+  char *property;
+
+  static struct option longopts[] = {
+          {"add",    required_argument, NULL, 'a'},
+          {"remove", required_argument, NULL, 'r'},
+          {"toggle", required_argument, NULL, 't'},
+          {"help",   no_argument,       NULL, 'h'},
+          {0, 0, 0,                           0},
+  };
+  int option_index = 0;
+  static const char *usage =
+          "Usage: %s [options] [window=%1]\n"
+                  HELP_SEE_WINDOW_STACK
+                  "--add property  - add a property\n"
+                  "--remove property - remove a property\n"
+                  "--toggle property - toggle a property\n"
+                  "property can be one of \n"
+                  "MODAL, STICKY, MAXIMIZED_VERT, MAXIMIZED_HORZ, SHADED, SKIP_TASKBAR, \n"
+                  "SKIP_PAGER, HIDDEN, FULLSCREEN, ABOVE, BELOW, DEMANDS_ATTENTION";
+  static int *errno_ptr;
+  errno_ptr = &errno;
+  while ((c = getopt_long_only(context->argc, context->argv, "+ha:r:t:",
+                               longopts, &option_index)) != -1) {
+    switch (c) {
+      case 'a':
+        action = _NET_WM_STATE_ADD;
+        arg_property = optarg;
+        break;
+      case 'r':
+        action = _NET_WM_STATE_REMOVE;
+        arg_property = optarg;
+        break;
+      case 't':
+        action = _NET_WM_STATE_TOGGLE;
+        arg_property = optarg;
+        break;
+      case 'h':
+        printf(usage, cmd);
+        consume_args(context, context->argc);
+        return EXIT_SUCCESS;
+      default:
+        fprintf(stderr, usage, cmd);
+        return EXIT_FAILURE;
+    }
+  }
+
+  consume_args(context, optind);
+
+  if (action == -1 || arg_property == NULL) {
+    return 1;
+  }
+
+  if (!window_get_arg(context, 0, 0, &window_arg)) {
+    fprintf(stderr, usage, cmd);
+    return 1;
+  }
+
+  property = parse_property(arg_property);
+  if (!property) {
+    return 1;
+  }
+
+  window_each(context, window_arg, {
+    ret = xdo_window_state(context->xdo, window, action, property);
+    if (ret) {
+      has_error = 1;
+      fprintf(stderr, "xdo_window_property reported an error on window %ld\n",
+              window);
+    }
+  }); /* window_each(...) */
+
+  free(property);
+  return has_error;
+} /* int cmd_windowstate(context_t *) */

--- a/xdo.c
+++ b/xdo.c
@@ -1879,6 +1879,26 @@ int xdo_get_window_name(const xdo_t *xdo, Window window,
   return 0;
 }
 
+int xdo_window_state(xdo_t *xdo, Window window, unsigned long action, const char *property) {
+  int ret;
+  XEvent xev;
+  Window root = RootWindow(xdo->xdpy, 0);
+
+  memset(&xev, 0, sizeof(xev));
+  xev.xclient.type = ClientMessage;
+  xev.xclient.serial = 0;
+  xev.xclient.send_event = True;
+  xev.xclient.message_type = XInternAtom(xdo->xdpy, "_NET_WM_STATE", False);
+  xev.xclient.window = window;
+  xev.xclient.format = 32;
+  xev.xclient.data.l[0] = action;
+  xev.xclient.data.l[1] = XInternAtom(xdo->xdpy, property, False);
+
+  ret = XSendEvent(xdo->xdpy, root, False,
+                   SubstructureNotifyMask | SubstructureRedirectMask, &xev);
+  return _is_success("XSendEvent[EWMH:_NET_WM_STATE]", ret == 0, xdo);
+}
+
 int xdo_minimize_window(const xdo_t *xdo, Window window) {
   int ret;
   int screen;

--- a/xdo.h
+++ b/xdo.h
@@ -613,6 +613,16 @@ int xdo_unmap_window(const xdo_t *xdo, Window wid);
  */
 int xdo_minimize_window(const xdo_t *xdo, Window wid);
 
+#define _NET_WM_STATE_REMOVE        0    /* remove/unset property */
+#define _NET_WM_STATE_ADD           1    /* add/set property */
+#define _NET_WM_STATE_TOGGLE        2    /* toggle property  */
+
+/**
+ * Change window state
+ * @param action the _NET_WM_STATE action
+ */
+int xdo_window_state(xdo_t *xdo, Window window, unsigned long action, const char *property);
+
 /** 
  * Reparents a window
  *

--- a/xdotool.c
+++ b/xdotool.c
@@ -257,6 +257,7 @@ struct dispatch {
   { "windowraise", cmd_windowraise, },
   { "windowreparent", cmd_windowreparent, },
   { "windowsize", cmd_windowsize, },
+  { "windowstate", cmd_windowstate, },
   { "windowunmap", cmd_windowunmap, },
 
   { "set_num_desktops", cmd_set_num_desktops, },

--- a/xdotool.h
+++ b/xdotool.h
@@ -72,6 +72,7 @@ int cmd_windowmove(context_t *context);
 int cmd_windowraise(context_t *context);
 int cmd_windowreparent(context_t *context);
 int cmd_windowsize(context_t *context);
+int cmd_windowstate(context_t *context);
 int cmd_windowunmap(context_t *context);
 /* pager-like commands */
 int cmd_set_num_desktops(context_t *context);


### PR DESCRIPTION
windowstate command can be used to make the window fullscreen, make the window below or above most windows.

see [this](https://specifications.freedesktop.org/wm-spec/wm-spec-1.3.html#idm140130317598336) for more detail.

Usage:
add fullscreen for window:
$ xdotool windowstate --add fullscreen $wid
remove fullscreen for window:
$ xdotool windowstate --remove fullscreen $wid
toggle fullscreen
$ xdotool windowstate --toggle fullscreen $wid