### PR TITLE
make build reproducible

### DIFF
--- a/version.sh
+++ b/version.sh
@@ -6,7 +6,9 @@ fi
 
 if [ -z "$MAJOR" -o -z "$RELEASE" -o -z "$REVISION" ] ; then
   MAJOR="3"
-  RELEASE="$(date +%Y%m%d)"
+  SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(date +%s)}"
+  DATE_FMT="+%Y%m%d"
+  RELEASE="$(date -u -d "@$SOURCE_DATE_EPOCH" "+$DATE_FMT" 2>/dev/null || date -u -r "$SOURCE_DATE_EPOCH" "+$DATE_FMT" 2>/dev/null || date -u "+$DATE_FMT")"
   REVISION=1
   #$([ -d .svn ] && svn info . | awk '/Revision:/ {print $2}')
   : ${REVISION=:0}


### PR DESCRIPTION
see https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/ for the definition of this variable
    
This invocation should work on GNU date and BSD date
