### PR TITLE
Add examples for set_desktop --relative

### DIFF
--- a/xdotool.pod
+++ b/xdotool.pod
@@ -837,6 +837,13 @@ current desktop.
 
 =back
 
+Examples:
+ # Change to desktop #5
+ xdotool set_desktop 5
+
+ # Change to the previous desktop. (Note the use of "--")
+ xdotool set_desktop --relative -- -1
+
 =item B<get_desktop>
 
 Output the current desktop in view.


### PR DESCRIPTION
it's not immediately clear that you have to use "--" in order that
negative numbers are parsed correctly:

---------
 $ xdotool set_desktop --relative -1
 set_desktop: unrecognized option '-1'
 Usage: set_desktop desktop
 --relative    - Move relative to the current desktop. Negative values OK

 $ xdotool set_desktop --relative -- -1
---------

This patch adds a clearer example.

(see https://bugs.debian.org/856654)