### PR TITLE
Document regular expressions

### DIFF
--- a/xdotool.pod
+++ b/xdotool.pod
@@ -361,6 +361,10 @@ is silent.
 The result is saved to the window stack for future chained commands. See
 L<WINDOW STACK> and L<COMMAND CHAINING> for details.
 
+Patterns are POSIX extended regular expressions (ERE), e. g. "Chrom(e|ium)$" for
+windows ending in "Chrome" or "Chromium". See L<regex(7)> for syntax details.
+Matches are case-insensitive.
+
 The default options are C<--name --class --classname> (unless you specify one or
 more of --name, --class or --classname).
 


### PR DESCRIPTION
The example is intended to quickly answer the question “do I need to use backslashes for groups in this flavor or not” without having to consult the manpage.

Fixes #172.