### PR TITLE
Fix build error on macOS/OS X 10.11 El Capitan

### DIFF
--- a/patch_clock_gettime.h
+++ b/patch_clock_gettime.h
@@ -1,6 +1,7 @@
 
 /* Hack support for clock_gettime into OS X */
 
+#if !defined(CLOCK_MONOTONIC)
 #define CLOCK_MONOTONIC 1
 typedef int clockid_t;
 int clock_gettime(clockid_t clk_id, struct timespec *res) {
@@ -13,3 +14,4 @@ int clock_gettime(clockid_t clk_id, struct timespec *res) {
   }
   return ret;
 }
+#endif


### PR DESCRIPTION
Currently, the existing hack in patch_clock_gettime.h assumes that `CLOCK_MONOTONIC` is not already defined. This assumption is not true on certain El Capitan installations, where Xcode 8 (or possibly newer) is installed, which includes the MacOSX10.12.sdk framework even on 10.11.

By checking whether `CLOCK_MONOTONIC` is already defined, and making sure the hack is ignored in that case, this commit fixes the following error on El Capitan:

```
In file included from cmd_behave_screen_edge.c:10:
./patch_clock_gettime.h:5:13: error: typedef redefinition with different types ('int' vs 'enum clockid_t')
typedef int clockid_t;
            ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk/usr/include/time.h:171:3: note: previous definition is here
} clockid_t;
  ^
1 error generated.
```

This issue is reproducible with either Homebrew or Xcode; see discussion at: https://github.com/Homebrew/homebrew-core/pull/19639