### PR TITLE
Remove declaration of xdo_get_active_keys_to_keycode_list

### DIFF
--- a/xdo.h
+++ b/xdo.h
@@ -411,15 +411,6 @@ int xdo_send_keysequence_window_list_do(const xdo_t *xdo, Window window,
                             charcodemap_t *keys, int nkeys,
                             int pressed, int *modifier, useconds_t delay);
 
-/**
- * Get a list of active keys. Uses XQueryKeymap.
- *
- * @param keys Pointer to the array of charcodemap_t that will be allocated
- *    by this function.
- * @param nkeys Pointer to integer where the number of keys will be stored.
- */
-int xdo_get_active_keys_to_keycode_list(const xdo_t *xdo, charcodemap_t **keys,
-                                         int *nkeys);
 
 /**
  * Wait for a window to have a specific map state.


### PR DESCRIPTION
First of all, thanks for making `libxdo` and `xdotool`! They're awesome.

This function was removed in 7cf1eaaf3178c46a12b73cf6454818b5d9feda75, but the header declaration was never removed. I came across this when writing [Crystal bindings](https://github.com/woodruffw/x_do.cr) for `libxdo`.
