### PR TITLE
fix extraneous '+' in VERSION and improve human -> xkeysym mappings

### DIFF
--- a/CHANGELIST
+++ b/CHANGELIST
@@ -8,6 +8,12 @@ KNOWN ISSUES:
 
 FOR TODO LIST, SEE TODO FILE :)
 
+3.20180106.1
+  - added 'return' -> 'Return', 'enter' -> 'Return'  mappings in xdo_util
+    to eliminate user gotchas not in man page.
+    removed extraneous '+' chars in version.sh; already present in DATE_FMT
+    (CSylvain)
+
 3.20160805.1
   - Fix release tool problem. cflags.sh was missing from the previous two
     releases. 

--- a/version.sh
+++ b/version.sh
@@ -8,7 +8,7 @@ if [ -z "$MAJOR" -o -z "$RELEASE" -o -z "$REVISION" ] ; then
   MAJOR="3"
   SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(date +%s)}"
   DATE_FMT="+%Y%m%d"
-  RELEASE="$(date -u -d "@$SOURCE_DATE_EPOCH" "+$DATE_FMT" 2>/dev/null || date -u -r "$SOURCE_DATE_EPOCH" "+$DATE_FMT" 2>/dev/null || date -u "+$DATE_FMT")"
+  RELEASE="$(date -u -d "@$SOURCE_DATE_EPOCH" "$DATE_FMT" 2>/dev/null || date -u -r "$SOURCE_DATE_EPOCH" "$DATE_FMT" 2>/dev/null || date -u "$DATE_FMT")"
   REVISION=1
   #$([ -d .svn ] && svn info . | awk '/Revision:/ {print $2}')
   : ${REVISION=:0}

--- a/xdo_util.h
+++ b/xdo_util.h
@@ -16,6 +16,8 @@ static const char *symbol_map[] = {
   "meta", "Meta_L",
   "super", "Super_L",
   "shift", "Shift_L",
+  "enter", "Return",
+  "return", "Return",
   NULL, NULL,
 };
 


### PR DESCRIPTION
3.20180106.1   - added 'return' -> 'Return', 'enter' -> 'Return'  mappings in xdo_util     to eliminate user gotchas not in man page.     removed extraneous '+' chars in version.sh; already present in DATE_FMT