### PR TITLE
Percent rework

### DIFF
--- a/cmd_windowmove.c
+++ b/cmd_windowmove.c
@@ -74,6 +74,7 @@ int cmd_windowmove(context_t *context) {
 
   const char *window_arg = "%1";
   int parse_flags;
+  unsigned int monitor_x, monitor_y;
 
   if (!window_get_arg(context, 2, 0, &window_arg)) {
     fprintf(stderr, usage, cmd);
@@ -88,6 +89,18 @@ int cmd_windowmove(context_t *context) {
     xdo_get_window_location(context->xdo, window,
                             (int *)&x, (int *)&y, NULL);
     xdo_get_xy(context->xdo, window, xarg, yarg, &x, &y, &parse_flags);
+    xdo_get_window_viewport_info(context->xdo, window, NULL, NULL,
+                                 &monitor_x, &monitor_y, NULL);
+
+
+    if (!(windowmove.flags & WINDOWMOVE_RELATIVE) &&
+        !(parse_flags & GETXY_ORIG_X) && (parse_flags & GETXY_MON_X)) {
+      x += monitor_x;
+    };
+    if (!(windowmove.flags & WINDOWMOVE_RELATIVE) &&
+        !(parse_flags & GETXY_ORIG_Y) && (parse_flags & GETXY_MON_Y)) {
+      y += monitor_y;
+    };
 
     windowmove.x = x;
     windowmove.y = y;

--- a/xdo.c
+++ b/xdo.c
@@ -2040,7 +2040,7 @@ static int _xdo_get_dir(const char *str, const char dir_char,
                         unsigned int mon_val, int *flags)
 {
   *flags = 0;
-  unsigned int raw_val;
+  double raw_val;
   char *percent;
 
   /* Just passing the direction gets you the unmodified value */
@@ -2049,7 +2049,7 @@ static int _xdo_get_dir(const char *str, const char dir_char,
     return XDO_SUCCESS;
   }
 
-  raw_val = (unsigned int)strtoul(str, NULL, 0);
+  raw_val = strtod(str, NULL);
   percent = strchr(str, '%');
   if (percent) {
     *flags = GETXY_PERCENT_X;

--- a/xdo.h
+++ b/xdo.h
@@ -900,4 +900,17 @@ int xdo_has_feature(xdo_t *xdo, int feature);
  */
 int xdo_get_viewport_dimensions(xdo_t *xdo, unsigned int *width,
                                 unsigned int *height, int screen);
+
+#define GETXY_ORIG_X    (1L << 0)
+#define GETXY_PERCENT_X (1L << 1)
+#define GETXY_ORIG_Y    (1L << 8)
+#define GETXY_PERCENT_Y (1L << 9)
+
+/**
+ * Calculate x/y from strings allowing for various percentages
+ *
+ */
+int xdo_get_xy(xdo_t *xdo, Window w, const char *xstr, const char *ystr,
+               unsigned int *x, unsigned int *y, int *flags);
+
 #endif /* ifndef _XDO_H_ */

--- a/xdo.h
+++ b/xdo.h
@@ -911,8 +911,10 @@ int xdo_get_window_viewport_info(xdo_t *xdo, Window w,
 
 #define GETXY_ORIG_X    (1L << 0)
 #define GETXY_PERCENT_X (1L << 1)
+#define GETXY_MON_X     (1L << 2)
 #define GETXY_ORIG_Y    (1L << 8)
 #define GETXY_PERCENT_Y (1L << 9)
+#define GETXY_MON_Y     (1L << 10)
 
 /**
  * Calculate x/y from strings allowing for various percentages

--- a/xdo.h
+++ b/xdo.h
@@ -901,6 +901,14 @@ int xdo_has_feature(xdo_t *xdo, int feature);
 int xdo_get_viewport_dimensions(xdo_t *xdo, unsigned int *width,
                                 unsigned int *height, int screen);
 
+/**
+ * Query the viewport for a given window.
+ */
+int xdo_get_window_viewport_info(xdo_t *xdo, Window w,
+                                unsigned int *width, unsigned int *height,
+                                unsigned int *x, unsigned int *y,
+                                int *screen_num);
+
 #define GETXY_ORIG_X    (1L << 0)
 #define GETXY_PERCENT_X (1L << 1)
 #define GETXY_ORIG_Y    (1L << 8)


### PR DESCRIPTION
This reworks the % options in windowsize and windowmove, to allow:
     30%m   to specify 30% of the current monitor
     x  (or y) to mean don't change (used to only work in windowmove)
     33.33%m   fractional percentages
