### PR TITLE
Fixes and features for cmd_behave

### DIFF
--- a/cmd_behave.c
+++ b/cmd_behave.c
@@ -172,10 +172,10 @@ int cmd_behave(context_t *context) {
          * we have to make sure we only fire on the type
          * that was requested. */
         if (e.type == eventtype) {
-            *tmpcontext.windows = e.xfocus.window;
-            ret = context_execute(&tmpcontext);
+          *tmpcontext.windows = e.xfocus.window;
+          ret = context_execute(&tmpcontext);
         } else {
-            ran_action = False;
+          ran_action = False;
         }
         break;
       case ButtonRelease:
@@ -190,10 +190,10 @@ int cmd_behave(context_t *context) {
       case GravityNotify:   /* caught by */
       case ReparentNotify:  /* StructureNotifyMask */
         if (e.type == eventtype) {
-            *tmpcontext.windows = e.xany.window;
-            ret = context_execute(&tmpcontext);
+          *tmpcontext.windows = e.xany.window;
+          ret = context_execute(&tmpcontext);
         } else {
-            ran_action = False;
+          ran_action = False;
         }
         break;
       default:
@@ -207,7 +207,7 @@ int cmd_behave(context_t *context) {
     }
 
     if(tmpcontext.windows != NULL) {
-        free(tmpcontext.windows);
+      free(tmpcontext.windows);
     }
 
     if (ran_action == True) {

--- a/cmd_behave.c
+++ b/cmd_behave.c
@@ -112,6 +112,7 @@ int cmd_behave(context_t *context) {
     // Copy context
     context_t tmpcontext = *context;
 
+    tmpcontext.windows = calloc(1, sizeof(Window));
     tmpcontext.nwindows = 1;
     Window hover; /* for LeaveNotify */
     switch (e.type) {
@@ -135,7 +136,7 @@ int cmd_behave(context_t *context) {
 
         /* fall through */
       case EnterNotify:
-        tmpcontext.windows = &(e.xcrossing.window);
+        *tmpcontext.windows = e.xcrossing.window;
         ret = context_execute(&tmpcontext);
         break;
       case FocusIn:
@@ -144,7 +145,7 @@ int cmd_behave(context_t *context) {
          * we have to make sure we only fire on the type
          * that was requested. */
         if (e.type == eventtype) {
-            tmpcontext.windows = &(e.xfocus.window);
+            *tmpcontext.windows = e.xfocus.window;
             ret = context_execute(&tmpcontext);
         } else {
             /* Set to success to avoid "Command failed." */
@@ -152,7 +153,7 @@ int cmd_behave(context_t *context) {
         }
         break;
       case ButtonRelease:
-        tmpcontext.windows = &(e.xbutton.window);
+        *tmpcontext.windows = e.xbutton.window;
         ret = context_execute(&tmpcontext);
         break;
       default:
@@ -162,6 +163,10 @@ int cmd_behave(context_t *context) {
 
     if (ret != XDO_SUCCESS) {
       xdotool_output(context, "Command failed.");
+    }
+
+    if(tmpcontext.windows != NULL) {
+        free(tmpcontext.windows);
     }
   }
   return ret;


### PR DESCRIPTION
This series of commits fixes

- the broken focus/blur events for the behave command
- a memory issue with the behave command

(see commits for details) as well as introduces the following new features:

- more (useful) events for behave
- possibility to return from the behave command.


In case the features are not wanted, i also have a "bugfix only" branch at [behave_fixes](/J0J0/xdotool/tree/behave_fixes).