### PR TITLE
Avoid integer overflow in position parsing.

### DIFF
--- a/xdotool.c
+++ b/xdotool.c
@@ -408,6 +408,10 @@ int script_main(int argc, char **argv) {
         if (isdigit(line[0])) {
           /* get the position of this parameter in argv */ 
           pos = atoi(line) + 1; /* $1 is actually index 2 in the argv array */
+          if (pos < 0) {
+            fprintf (stderr, "%s: error: invalid argument position", line);
+            return EXIT_FAILURE;
+          }
 
           /* bail if no argument was given for this parameter */
           if (pos >= argc) {


### PR DESCRIPTION
It is possible to trigger an integer overflow in position parsing
if INT_MAX has been supplied. In that case, the addition of 1 leads
to an overflow, turning pos negative. This will eventually lead to
an out of boundary access.

Signed-off-by: Tobias Stoeckmann <tobias@stoeckmann.org>