### PR TITLE
Fix out of boundary access on empty lines.

### DIFF
--- a/xdotool.c
+++ b/xdotool.c
@@ -370,7 +370,7 @@ int script_main(int argc, char **argv) {
     line += strspn(line, " \t");
 
     /* blanklines or line comment are ignored, too */
-    if (line[0] == '\n' || line[0] == '#') {
+    if (line[0] == '\0' || line[0] == '\n' || line[0] == '#') {
       continue;
     }
 


### PR DESCRIPTION
If an empty line without newline or a line starting with '\0' is
encountered, an out of boundary access occurs due to usage of
strlen(line)-1.

Just skip such lines as empty or commented lines are skipped as well.

Signed-off-by: Tobias Stoeckmann <tobias@stoeckmann.org>