### PR TITLE
Teach getwindowgeometry to output hinted size

### DIFF
--- a/cmd_getwindowgeometry.c
+++ b/cmd_getwindowgeometry.c
@@ -5,6 +5,7 @@ int cmd_getwindowgeometry(context_t *context) {
   int x, y;
   Screen *screen;
   unsigned int width, height;
+  unsigned int hinted_width, hinted_height;
 
   int shell_output = False;
   char out_prefix[17] = {'\0'};
@@ -64,18 +65,23 @@ int cmd_getwindowgeometry(context_t *context) {
       fprintf(stderr, "window %ld - failed to get location?\n", window);
     }
 
+    xdo_get_window_hinted_size(context->xdo, window, &hinted_width, &hinted_height);
+
     if (shell_output) {
       xdotool_output(context, "%sWINDOW=%ld", out_prefix, window);
       xdotool_output(context, "%sX=%d", out_prefix, x);
       xdotool_output(context, "%sY=%d", out_prefix, y);
       xdotool_output(context, "%sWIDTH=%u", out_prefix, width);
       xdotool_output(context, "%sHEIGHT=%u", out_prefix, height);
+      xdotool_output(context, "%sHINTEDWIDTH=%u", out_prefix, hinted_width);
+      xdotool_output(context, "%sHINTEDHEIGHT=%u", out_prefix, hinted_height);
       xdotool_output(context, "%sSCREEN=%d", out_prefix, XScreenNumberOfScreen(screen));
     } else {
       xdotool_output(context, "Window %ld", window);
       xdotool_output(context, "  Position: %d,%d (screen: %d)", x, y,
                      XScreenNumberOfScreen(screen));
       xdotool_output(context, "  Geometry: %ux%u", width, height);
+      xdotool_output(context, "  Hinted geometry: %ux%u", hinted_width, hinted_height);
     }
   }); /* window_each(...) */
   return EXIT_SUCCESS;

--- a/xdo.c
+++ b/xdo.c
@@ -247,6 +247,39 @@ int xdo_get_window_size(const xdo_t *xdo, Window wid, unsigned int *width_ret,
   return _is_success("XGetWindowAttributes", ret == 0, xdo);
 }
 
+int xdo_get_window_hinted_size(const xdo_t *xdo, Window window,
+                               unsigned int *hinted_width_ret,
+                               unsigned int *hinted_height_ret) {
+
+  XSizeHints hints;
+  long supplied_return;
+  unsigned int width = 0;
+  unsigned int height = 0;
+  xdo_get_window_size(xdo, window, &width, &height);
+  XGetWMNormalHints(xdo->xdpy, window, &hints, &supplied_return);
+  if (supplied_return & PResizeInc
+      && hints.width_inc != 0 && hints.height_inc != 0
+      && width != 0 && height != 0) {
+    if (hints.flags & (PMinSize | PBaseSize)) {
+      if (hints.flags & PBaseSize) {
+        width -= hints.base_width;
+        height -= hints.base_height;
+      } else {
+        width -= hints.min_width;
+        height -= hints.min_height;
+      }
+    }
+    *hinted_width_ret = width/hints.width_inc;
+    *hinted_height_ret = height/hints.height_inc;
+  } else {
+    fprintf(stderr, "No size hints found for window %ld\n", window);
+    *hinted_width_ret = 0;
+    *hinted_height_ret = 0;
+  }
+
+  return XDO_SUCCESS;
+}
+
 int xdo_move_window(const xdo_t *xdo, Window wid, int x, int y) {
   XWindowChanges wc;
   int ret = 0;

--- a/xdo.h
+++ b/xdo.h
@@ -646,6 +646,18 @@ int xdo_get_window_location(const xdo_t *xdo, Window wid,
 int xdo_get_window_size(const xdo_t *xdo, Window wid, unsigned int *width_ret,
                         unsigned int *height_ret);
 
+/**
+ * Get a window's size in the size hints increment unit
+ * Will be 0 if window doesn't have any size hints.
+ *
+ * @param window the window to use
+ * @param hinted_width_ret width in size hints unit
+ * @param hinted_height_ret height in size hints unit
+ */
+int xdo_get_window_hinted_size(const xdo_t *xdo, Window window,
+                               unsigned int *hinted_width_ret,
+                               unsigned int *hinted_height_ret);
+
 /* pager-like behaviors */
 
 /**


### PR DESCRIPTION
Get size hints for a window and output the geometry in these increment
units. Useful for fetching the columns-x-lines size of, typically,
terminal windows.Teach getwindowgeometry to output hinted size