### PR TITLE
Fix leak in _xdo_populate_charcode_map

### DIFF
--- a/xdo.c
+++ b/xdo.c
@@ -1336,7 +1336,7 @@ static void _xdo_populate_charcode_map(xdo_t *xdo) {
     }
   }
   xdo->charcodes_len = idx;
-  XkbFreeClientMap(desc, 0, 1);
+  XkbFreeKeyboard(desc, 0, 1);
   XFreeModifiermap(modmap);
 }
 


### PR DESCRIPTION
With this change I see the following program no longer leak:

```C
#include <xdo.h>
#include <assert.h>

int main() {
	xdo_t *xdo = xdo_new(NULL);
	assert(xdo);
	xdo_free(xdo);
}
```
```console
$ gcc -Wall -Wextra -g3 -I ../xdotool -fsanitize=address -fno-omit-frame-pointer xdwim.c ../xdotool/libxdo.a -lX11 -lX11 -lXtst -lXinerama -lxkbcommon -lasan
$ ./a.out
```
If I remove my change I get:
```console
$ ./a.out 
=================================================================
==11749==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 72 byte(s) in 1 object(s) allocated from:
    #0 0x7f753582be10 in calloc (/lib64/libasan.so.5+0xefe10)
    #1 0x7f753568e1a4 in XkbGetMap /usr/src/debug/libX11-1.6.7-1.fc29.x86_64/src/xkb/XKBGetMap.c:598

SUMMARY: AddressSanitizer: 72 byte(s) leaked in 1 allocation(s).
```

Fixes https://github.com/jordansissel/xdotool/issues/189

Signed-off-by: Andrew McDermott <aim@frobware.com>