### PR TITLE
Fix stdout not returning the line on type command

### DIFF
--- a/cmd_type.c
+++ b/cmd_type.c
@@ -205,6 +205,7 @@ int cmd_type(context_t *context) {
   free(data);
 
   consume_args(context, args_count);
+  printf("\n");
   return ret > 0;
 }
 


### PR DESCRIPTION
When type command is used (from the command line) xdotool stdout unintentionally the typed text without returning to a new line 
