### PR TITLE
Search --pid without regexp_argument

### DIFF
--- a/cmd_search.c
+++ b/cmd_search.c
@@ -172,7 +172,9 @@ int cmd_search(context_t *context) {
       search.searchmask |= SEARCH_CLASSNAME;
       search.winclassname = context->argv[0];
     }
-    consume_args(context, 1);
+    if (search_title || search_name || search_class || search_classname) {
+      consume_args(context, 1);
+    }
   }
 
   do {

--- a/cmd_search.c
+++ b/cmd_search.c
@@ -148,7 +148,7 @@ int cmd_search(context_t *context) {
   }
 
   if (context->argc > 0) {
-    if (!search_title && !search_name && !search_class && !search_classname) {
+    if (!search.pid && !search_title && !search_name && !search_class && !search_classname) {
       fprintf(stderr, "Defaulting to search window name, class, and classname\n");
       search.searchmask |= (SEARCH_NAME | SEARCH_CLASS | SEARCH_CLASSNAME);
       search_name = 1;


### PR DESCRIPTION
Implement pid searching without additional `search` argument to allow commands like:
```bash
$ xdotool search --pid 123 set_window --urgency 1
```

I don't think it made much sense to search by name *and* pid, previously you had to do something like this:
```bash
$ ./xdotool search --pid 123  name_that_does_not_exist set_window --urgency 1
Defaulting to search window name, class, and classname
```

Fixes #14 