### PR TITLE
Subtract title height and left border width (fixes #176)

### DIFF
--- a/xdo.c
+++ b/xdo.c
@@ -212,7 +212,7 @@ int xdo_get_window_location(const xdo_t *xdo, Window wid,
       y = attr.y;
     } else {
       XTranslateCoordinates(xdo->xdpy, wid, attr.root,
-                            attr.x, attr.y, &x, &y, &unused_child);
+                            -attr.x, -attr.y, &x, &y, &unused_child);
     }
 
     if (x_ret != NULL) {


### PR DESCRIPTION
xdotool needs to subtract decorations when reporting window position.   Using these fixed values with `windowmove` will result placing window correctly at the current position.

Current users get value which is outright wrong (absolute position as reported by `xwininfo` plus decorations).  Possible useful values to user are absolute position (drawable part of window) or window position (sans decorations) which is what this patch provides.

Either fix will slightly break existing users unless both are provided as option or new command.