### PR TITLE
xdo_get_window_location provides correct location

### DIFF
--- a/xdo.c
+++ b/xdo.c
@@ -212,7 +212,7 @@ int xdo_get_window_location(const xdo_t *xdo, Window wid,
       y = attr.y;
     } else {
       XTranslateCoordinates(xdo->xdpy, wid, attr.root,
-                            attr.x, attr.y, &x, &y, &unused_child);
+                            0, 0, &x, &y, &unused_child);
     }
 
     if (x_ret != NULL) {


### PR DESCRIPTION
The previous implementation interpreted of xdo_get_window_location the first set of x,y coordinates to _XTranslateCoordinates_ as being relative to the parent origin. This translated the real x,y coordinates location by attr.x and attr.y respectively where attr is the window attributes. However, it is relative to the screen origin. See: [_XTranslateCoordinates_ Documentation](https://tronche.com/gui/x/xlib/window-information/XTranslateCoordinates.html); specifically the src_x and src_y fields:

> Specify the x and y coordinates within the source window. 

Practical example - Point the mouse cursor at the window origin (in this case xclock) and then to the very edge border pixel:

**Old:**
![xdoold](https://user-images.githubusercontent.com/3581121/85446195-2aefc300-b562-11ea-9524-d2be8e455e08.gif)

**New:**
![newxdo](https://user-images.githubusercontent.com/3581121/85446154-22978800-b562-11ea-98f3-338521cffae8.gif)


Script run in gifs:
```
#!/bin/bash
xclock &
sleep 1
pid=$(ps -a | grep xclock | awk '{print $1}')
window=$(xdotool search --pid ${pid})
location=$(xdotool getwindowgeometry $window | awk '/,/ {print $2}')
x=$(echo ${location} | awk '{split($1,a,","); print a[1];}')
y=$(echo ${location} | awk '{split($1,a,","); print a[2];}')
xdotool mousemove $x $y
sleep 3
let y-=45
xdotool mousemove $x $y
#45 from XWindowAttributes.y (Dist from parent)
```

