### PR TITLE
search --role

### DIFF
--- a/xdo.h
+++ b/xdo.h
@@ -159,6 +159,11 @@ typedef struct xdo {
  */
 #define SEARCH_DESKTOP (1UL << 7)
 
+/**
+ * Search only window role.
+ * @see xdo_search
+ */
+#define SEARCH_ROLE (1UL << 8)
 
 /**
  * The window search query structure.
@@ -170,6 +175,7 @@ typedef struct xdo_search {
   const char *winclass;     /** pattern to test against a window class */
   const char *winclassname; /** pattern to test against a window class */
   const char *winname;      /** pattern to test against a window name */
+  const char *winrole;      /** pattern to test against a window role */
   int pid;            /** window pid (From window atom _NET_WM_PID) */
   long max_depth;     /** depth of search. 1 means only toplevel windows */
   int only_visible;   /** boolean; set true to search only visible windows */

--- a/xdotool.pod
+++ b/xdotool.pod
@@ -365,8 +365,8 @@ Patterns are POSIX extended regular expressions (ERE), e. g. "Chrom(e|ium)$" for
 windows ending in "Chrome" or "Chromium". See L<regex(7)> for syntax details.
 Matches are case-insensitive.
 
-The default options are C<--name --class --classname> (unless you specify one or
-more of --name, --class or --classname).
+The default options are C<--name --class --classname --role>
+(unless you specify one or more of --name, --class, --classname, or --role).
 
 The options available are:
 
@@ -379,6 +379,10 @@ Match against the window class.
 =item B<--classname>
 
 Match against the window classname.
+
+=item B<--rolw>
+
+Match against the window role.
 
 =item B<--maxdepth> N
 


### PR DESCRIPTION
Add `--role` option to `search` command, gaining the ability to filter windows by _role_,

_Role_ is the `WM_WINDOW_ROLE` property presented at https://www.x.org/releases/X11R7.6/doc/xorg-docs/specs/ICCCM/icccm.html#client_support_for_session_management

This attempt is similar to what was tried in 2013 at #34 

This feature is instrumental for those having to work with apps like `gnome-terminal`, which don't use `class` & `name` per window context, e.g.:
```
$ gnome-terminal --help-all
…
GTK+ Options
  --class=CLASS    Program class as used by the window manager
  --name=NAME    Program name as used by the window manager
…
Window options; if used before the first --window or --tab argument, sets the default for all windows:
…
  --role=ROLE    Set the window role
…
$ gnome-terminal --name=myname --class=myclass --role=myrole
$ xprop WM_CLASS WM_WINDOW_ROLE _NET_WM_NAME WM_NAME
WM_CLASS(STRING) = "gnome-terminal-server", "Gnome-terminal"
WM_WINDOW_ROLE(STRING) = "myrole"
_NET_WM_NAME(UTF8_STRING) = "xprop WM_CLASS WM_WINDOW_ROLE _NET_WM_NAME WM_NAME"
WM_NAME(COMPOUND_TEXT) = "xprop WM_CLASS WM_WINDOW_ROLE _NET_WM_NAME WM_NAME"
```
