### PR TITLE
Add windowquit option and get tests working

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ CMDOBJS= cmd_click.o cmd_mousemove.o cmd_mousemove_relative.o cmd_mousedown.o \
          cmd_windowkill.o cmd_behave.o cmd_window_select.o \
          cmd_getwindowname.o cmd_behave_screen_edge.o \
          cmd_windowminimize.o cmd_exec.o cmd_getwindowgeometry.o \
-         cmd_windowclose.o \
+         cmd_windowclose.o cmd_windowquit.o \
          cmd_sleep.o cmd_get_display_geometry.o
 
 .PHONY: all

--- a/cmd_windowquit.c
+++ b/cmd_windowquit.c
@@ -1,0 +1,49 @@
+#include "xdo_cmd.h"
+
+int cmd_windowquit(context_t *context) {
+  int ret = 0;
+  char *cmd = *context->argv;
+  const char *window_arg = "%1";
+
+  int c;
+  static struct option longopts[] = {
+    { "help", no_argument, NULL, 'h' },
+    { 0, 0, 0, 0 },
+  };
+  static const char *usage =
+    "Usage: %s [window=%1]\n"
+    HELP_SEE_WINDOW_STACK;
+  int option_index;
+
+  while ((c = getopt_long_only(context->argc, context->argv, "+h",
+                               longopts, &option_index)) != -1) {
+    switch (c) {
+      case 'h':
+        printf(usage, cmd);
+        consume_args(context, context->argc);
+        return EXIT_SUCCESS;
+        break;
+      default:
+        fprintf(stderr, usage, cmd);
+        return EXIT_FAILURE;
+    }
+  }
+
+  consume_args(context, optind);
+
+  if (!window_get_arg(context, 0, 0, &window_arg)) {
+    fprintf(stderr, usage, cmd);
+    return EXIT_FAILURE;
+  }
+
+  window_each(context, window_arg, {
+    ret = xdo_quit_window(context->xdo, window);
+    if (ret) {
+      fprintf(stderr, "xdo_quit_window reported an error on window %ld\n",
+              window);
+    }
+  }); /* window_each(...) */
+
+  return ret;
+} /* int cmd_windowquit(context_t *) */
+

--- a/t/xdo_test_helper.rb
+++ b/t/xdo_test_helper.rb
@@ -181,3 +181,7 @@ module XdoTestHelper
         "Mouse Y position expected to be near #{y}, is #{my} (+- #{tolerance} pixels)")
   end # def assert_mouse_position
 end # module XdoTestHelper
+
+def assert_not_equal vala, valb, message
+  assert vala != valb, message
+end

--- a/xdo.c
+++ b/xdo.c
@@ -1851,6 +1851,29 @@ int xdo_close_window(const xdo_t *xdo, Window window) {
   return _is_success("XDestroyWindow", ret == 0, xdo);
 }
 
+int xdo_quit_window(const xdo_t *xdo, Window window) {
+  XEvent xev;
+  int ret;
+  Window root = RootWindow(xdo->xdpy, 0);
+
+  memset(&xev, 0, sizeof(xev));
+  xev.type = ClientMessage;
+  xev.xclient.serial = 0;
+  xev.xclient.send_event = True;
+  xev.xclient.display = xdo->xdpy;
+  xev.xclient.window = window;
+  xev.xclient.message_type = XInternAtom(xdo->xdpy, "_NET_CLOSE_WINDOW", False);
+  xev.xclient.format = 32;
+
+  ret = XSendEvent(xdo->xdpy, root, False,
+                   SubstructureNotifyMask | SubstructureRedirectMask,
+                   &xev);
+
+  /* XXX: XSendEvent returns 0 on conversion failure, nonzero otherwise.
+   * Manpage says it will only generate BadWindow or BadValue errors */
+  return _is_success("XSendEvent[_NET_CLOSE_WINDOW]", ret == 0, xdo);
+}
+
 int xdo_get_window_name(const xdo_t *xdo, Window window, 
                         unsigned char **name_ret, int *name_len_ret,
                         int *name_type) {

--- a/xdo.h
+++ b/xdo.h
@@ -836,6 +836,12 @@ int xdo_kill_window(const xdo_t *xdo, Window window);
 int xdo_close_window(const xdo_t *xdo, Window window);
 
 /**
+ * Request that a window close, gracefully.
+ *
+ */
+int xdo_quit_window(const xdo_t *xdo, Window window);
+
+/**
  * Find a client window that is a parent of the window given
  */
 #define XDO_FIND_PARENTS (0)

--- a/xdotool.c
+++ b/xdotool.c
@@ -248,6 +248,7 @@ struct dispatch {
   { "windowfocus", cmd_windowfocus, },
   { "windowkill", cmd_windowkill, },
   { "windowclose", cmd_windowclose, },
+  { "windowquit", cmd_windowquit, },
   { "windowmap", cmd_windowmap, },
   { "windowminimize", cmd_windowminimize, },
   { "windowmove", cmd_windowmove, },

--- a/xdotool.h
+++ b/xdotool.h
@@ -66,6 +66,7 @@ int cmd_windowactivate(context_t *context);
 int cmd_windowfocus(context_t *context);
 int cmd_windowkill(context_t *context);
 int cmd_windowclose(context_t *context);
+int cmd_windowquit(context_t *context);
 int cmd_windowmap(context_t *context);
 int cmd_windowminimize(context_t *context);
 int cmd_windowmove(context_t *context);

--- a/xdotool.pod
+++ b/xdotool.pod
@@ -698,6 +698,12 @@ Close a window. This action will destroy the window, but will not try
 to kill the client controlling it. If no window is given, %1 is the
 default. See L<WINDOW STACK> and L<COMMAND CHAINING> for more details.
 
+=item B<windowquit> I<[window]>
+
+Close a window gracefully. This action sends a request, allowing the
+application to apply close confirmation mechanics. If no window is given, %1
+is the default. See L<WINDOW STACK> and L<COMMAND CHAINING> for more details.
+
 =item B<windowkill> I<[window]>
 
 Kill a window. This action will destroy the window and kill the client


### PR DESCRIPTION
Send a `_NET_WINDOW_CLOSE` event to a given window.  This allows for a graceful window shutdown, as opposed to the existing windowclose, which is too rude, and windowkill, which is too lethal.