### PR TITLE
getmouselocation now updates the window stack.

### DIFF
--- a/cmd_getmouselocation.c
+++ b/cmd_getmouselocation.c
@@ -52,7 +52,11 @@ int cmd_getmouselocation(context_t *context) {
     xdotool_output(context, "%sSCREEN=%d", out_prefix, screen_num);
     xdotool_output(context, "%sWINDOW=%d", out_prefix, window);
   } else {
-    xdotool_output(context, "x:%d y:%d screen:%d window:%ld", x, y, screen_num, window);
+    /* only print if we're the last command */
+    if (context->argc == 0) {
+      xdotool_output(context, "x:%d y:%d screen:%d window:%ld", x, y, screen_num, window);
+    }
+    window_save(context, window);
   }
   return ret;
 }

--- a/xdotool.pod
+++ b/xdotool.pod
@@ -260,6 +260,8 @@ Same as B<click>, except only a mouse up is sent.
 Outputs the x, y, screen, and window id of the mouse cursor. Screen numbers will
 be nonzero if you have multiple monitors and are not using Xinerama.
 
+This command updates the window stack with the window id of the window directly underneath the mouse.
+
 =over
 
 =item B<--shell>


### PR DESCRIPTION
This allows you to do 'getmouselocation windowactivate' for example, to
activate the window the mouse is currently hovering over.

Add docs about getmouselocation updating the window stack.

Fixes #118