### PR TITLE
Fix permissions on installed xdo.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ installlib: libxdo.$(LIBSUFFIX)
 .PHONY: installheader
 installheader: xdo.h
 	install -d $(DINSTALLINCLUDE)
-	install xdo.h $(DINSTALLINCLUDE)/xdo.h
+	install -m 0644 xdo.h $(DINSTALLINCLUDE)/xdo.h
 
 .PHONY: installpc
 installpc: libxdo.pc


### PR DESCRIPTION
It was getting installed in `/usr/lib/pkgconfig` (even though the lib dir was set), with permissions `rwxr-xr-x` (0755).

It's normal to install .pc files without executable flags.