### PR TITLE
Add extern "C" guards

### DIFF
--- a/xdo.h
+++ b/xdo.h
@@ -14,6 +14,10 @@
 #include <unistd.h>
 #include <wchar.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @mainpage
  *
@@ -912,4 +916,9 @@ int xdo_has_feature(xdo_t *xdo, int feature);
  */
 int xdo_get_viewport_dimensions(xdo_t *xdo, unsigned int *width,
                                 unsigned int *height, int screen);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #endif /* ifndef _XDO_H_ */

--- a/xdo_cmd.h
+++ b/xdo_cmd.h
@@ -14,6 +14,10 @@
 #include "xdo.h"
 #include "xdotool.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define HELP_SEE_WINDOW_STACK \
   "If no window is given, %1 is used. See WINDOW STACK in xdotool(1)\n"
 #define HELP_CHAINING_ENDS \
@@ -34,5 +38,9 @@ extern int window_get_arg(context_t *context, int min_arg, int window_arg_pos,
 
 extern void xdotool_debug(context_t *context, const char *format, ...);
 extern void xdotool_output(context_t *context, const char *format, ...);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* _XDO_CMD_H_ */

--- a/xdotool.h
+++ b/xdotool.h
@@ -1,6 +1,10 @@
 #ifndef _XDOTOOL_H_
 #define _XDOTOOL_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* TODO(sissel): use proper printf format depending on the storage
  * size of Window (could be 4 or 8 bytes depending on platform */
 #define window_print(window) (printf("%ld\n", window))
@@ -86,5 +90,9 @@ int cmd_get_desktop_for_window(context_t *context);
 int cmd_set_desktop_viewport(context_t *context);
 int cmd_get_desktop_viewport(context_t *context);
 int cmd_get_display_geometry(context_t *context);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* _XDOTOOL_H_ */


### PR DESCRIPTION
The year is 2021. All C libraries are _expected_ to wrap their headers with `extern "C"` so they can be used from C++. It is literally 6 lines and it saves hundreds of frustrating linker errors.

Fixes #63.