### PR TITLE
Detect if the X server is XWayland and report an error.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ test: xdotool libxdo.$(VERLIBSUFFIX)
 	fi
 	SHELL=$(WITH_SHELL) $(MAKE) -C t
 
-xdo_version.h:
+xdo_version.h: VERSION
 	sh version.sh --header > $@
 
 VERSION:

--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,8 @@ DEFAULT_LIBS=-L/usr/X11R6/lib -L/usr/local/lib -lX11 -lXtst -lXinerama -lxkbcomm
 DEFAULT_INC=-I/usr/X11R6/include -I/usr/local/include
 
 XDOTOOL_LIBS=$(shell pkg-config --libs x11 2> /dev/null || echo "$(DEFAULT_LIBS)")  $(shell sh platform.sh extralibs)
-LIBXDO_LIBS=$(shell pkg-config --libs x11 xtst xinerama xkbcommon 2> /dev/null || echo "$(DEFAULT_LIBS)")
-INC=$(shell pkg-config --cflags x11 xtst xinerama xkbcommon 2> /dev/null || echo "$(DEFAULT_INC)")
+LIBXDO_LIBS=$(shell pkg-config --libs xi x11 xtst xinerama xkbcommon 2> /dev/null || echo "$(DEFAULT_LIBS)")
+INC=$(shell pkg-config --cflags xi x11 xtst xinerama xkbcommon 2> /dev/null || echo "$(DEFAULT_INC)")
 CFLAGS+=-std=c99 $(INC)
 
 CMDOBJS= cmd_click.o cmd_mousemove.o cmd_mousemove_relative.o cmd_mousedown.o \

--- a/version.sh
+++ b/version.sh
@@ -7,7 +7,7 @@ fi
 if [ -z "$MAJOR" -o -z "$RELEASE" -o -z "$REVISION" ] ; then
   MAJOR="3"
   SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(date +%s)}"
-  DATE_FMT="+%Y%m%d"
+  DATE_FMT="%Y%m%d"
   RELEASE="$(date -u -d "@$SOURCE_DATE_EPOCH" "+$DATE_FMT" 2>/dev/null || date -u -r "$SOURCE_DATE_EPOCH" "+$DATE_FMT" 2>/dev/null || date -u "+$DATE_FMT")"
   REVISION=1
   #$([ -d .svn ] && svn info . | awk '/Revision:/ {print $2}')

--- a/xdo.c
+++ b/xdo.c
@@ -2048,6 +2048,7 @@ int appears_to_be_wayland(Display *xdpy) {
     // If the input device name starts with "xwayland-", 
     // there's a good chance we're running on XWayland.
     if (strstr(devices[i].name, "xwayland-") == devices[i].name) {
+      XFreeDeviceList(devices);
       return 1; // Running on wayland
     }
   }

--- a/xdotool.c
+++ b/xdotool.c
@@ -521,6 +521,14 @@ int args_main(int argc, char **argv) {
     exit(1);
   }
 
+  if (!strcasecmp(argv[1], "help")) {
+    cmd_help(NULL);
+    exit(EXIT_SUCCESS);
+  } else if (!strcasecmp(argv[1], "version")) {
+    cmd_version(NULL);
+    exit(EXIT_SUCCESS);
+  }
+
   while ((opt = getopt_long_only(argc, argv, "++hv", long_options, &option_index)) != -1) {
     switch (opt) {
       case 'h':
@@ -547,7 +555,7 @@ int args_main(int argc, char **argv) {
   context.debug = (getenv("DEBUG") != NULL);
 
   if (context.xdo == NULL) {
-    fprintf(stderr, "Failed creating new xdo instance\n");
+    fprintf(stderr, "Failed creating new xdo instance.\n");
     return 1;
   }
   context.xdo->debug = context.debug;


### PR DESCRIPTION
Also: Detect if $DISPLAY env is not set and report a more informative
error message.

For the purposes of libxdo/xdotool, XWayland does not work, so it's best
to notify the user accordingly if detected.

This adds a dependency on XInput `libxi` because the only[1] way I have
found to detect XWayland is through this extension

[1] There is another detection method which uses
  XFree86-VidModeExtension, but I don't know how common that extension is
  compared to XInput2.

Fixes #341.
Related to #337.