### PR TITLE
Change OSX to macOS and add MacPorts instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You may find xdotool in your distribution packaging:
 * Debian and Ubuntu: `apt-get install xdotool`
 * Fedora: `dnf install xdotool`
 * FreeBSD: `pkg install xdotool`
-* OSX: `brew install xdotool`
+* macOS: `brew install xdotool` or `sudo port install xdotool`
 * OpenSUSE: `zypper install xdotool`
 
 ## Basic Usage


### PR DESCRIPTION
This PR changes OSX to macOS (Apple changed the OS name some years ago) and adds installation instructions using MacPorts to the existing instructions for using Homebrew.

The same changes should be made to the web page at https://www.semicomplete.com/projects/xdotool/#installing