### PR TITLE
Typo: move a window is not the business of get_desktop_for_window

### DIFF
--- a/xdotool.pod
+++ b/xdotool.pod
@@ -907,9 +907,9 @@ default. See L<WINDOW STACK> and L<COMMAND CHAINING> for more details.
 
 =item B<get_desktop_for_window> I<[window]>
 
-Output the desktop currently containing the given window. Move a window to a
-different desktop. If no window is given, %1 is the default. See L<WINDOW
-STACK> and L<COMMAND CHAINING> for more details.
+Output the desktop currently containing the given window. If no window
+is given, %1 is the default. See L<WINDOW STACK> and L<COMMAND CHAINING>
+for more details.
 
 =back
 


### PR DESCRIPTION
Fixes issue https://github.com/jordansissel/xdotool/issues/351

``get_desktop_for_window`` description has the exact same sentence as ``set_desktop_for_window`` description. Both descriptions are adjacent. Since moving is not the business of a ``get`` command, this is most probably some sort of an extension to the wrong place. But I have not checked the actual C code. Perhaps this is a more fundamental error.