### PR TITLE
Fix #362 to have `make create-package-deb` work again.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 *.1
 libxdo.pc
 xdotool
+deb-build
+*.deb

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,8 @@ uninstall:
 .PHONY: clean
 clean:
 	rm -f *.o xdotool xdotool.static xdotool.1 xdotool.html \
-	      libxdo.$(LIBSUFFIX) libxdo.$(VERLIBSUFFIX) libxdo.a libxdo.pc
+	      libxdo.$(LIBSUFFIX) libxdo.$(VERLIBSUFFIX) libxdo.a libxdo.pc \
+	      *.deb
 
 xdo.o: xdo.c xdo_version.h
 	$(CC) $(CFLAGS) -fPIC -c xdo.c

--- a/Makefile
+++ b/Makefile
@@ -235,7 +235,7 @@ test-package-build: create-package
 # tarballs.
 
 DEBDIR=deb-build
-create-package-deb: pre-create-package VERSION xdo_version.h
+create-package-deb: VERSION xdo_version.h
 	[ -d $(DEBDIR) ] && rm -r $(DEBDIR) || true
 	$(MAKE) xdotool.deb xdotool-doc.deb libxdo$(MAJOR).deb libxdo$(MAJOR)-dev.deb
 
@@ -270,18 +270,18 @@ $(DEBDIR)/%/control.tar.gz: $(DEBDIR)/%/control $(DEBDIR)/%/md5sums
 	tar -C $(DEBDIR)/$* -zcf $(DEBDIR)/$*/control.tar.gz control md5sums 
 
 # Build a tarball for xdotool files
-$(DEBDIR)/xdotool/data.tar.gz: $(DEBDIR)/xdotool/
+$(DEBDIR)/xdotool/data.tar.gz: $(DEBDIR)/xdotool
 	tar -C $(DEBDIR) -zcf $@ usr/bin
 
 # Build a tarball for libxdo# files
-$(DEBDIR)/libxdo$(MAJOR)/data.tar.gz: $(DEBDIR)/libxdo$(MAJOR)/
+$(DEBDIR)/libxdo$(MAJOR)/data.tar.gz: $(DEBDIR)/libxdo$(MAJOR)
 	tar -C $(DEBDIR) -zcf $@ usr/lib
 
 # Build a tarball for libxdo#-dev files
-$(DEBDIR)/libxdo$(MAJOR)-dev/data.tar.gz: $(DEBDIR)/libxdo$(MAJOR)-dev/
+$(DEBDIR)/libxdo$(MAJOR)-dev/data.tar.gz: $(DEBDIR)/libxdo$(MAJOR)-dev
 	tar -C $(DEBDIR) -zcf $@ usr/include
 
 # Build a tarball for xdotool-doc files
-$(DEBDIR)/xdotool-doc/data.tar.gz: $(DEBDIR)/xdotool-doc/
+$(DEBDIR)/xdotool-doc/data.tar.gz: $(DEBDIR)/xdotool-doc
 	tar -C $(DEBDIR) -zcf $@ usr/share
 


### PR DESCRIPTION
Reported in #362, the `make create-package-deb` make target was failing. This PR fixes the issue.

Fixes #362.

```
% make create-package-deb                                                                                                                                                                                  
...
```