### PR TITLE
Keep code style & add va_end

### DIFF
--- a/xdo.c
+++ b/xdo.c
@@ -1987,6 +1987,7 @@ void _xdo_debug(const xdo_t *xdo, const char *format, ...) {
     vfprintf(stderr, format, args);
     fprintf(stderr, "\n");
   }
+  va_end(args);
 } /* _xdo_debug */
 
 /* Used for printing things conditionally based on xdo->quiet */
@@ -2000,6 +2001,7 @@ void _xdo_eprintf(const xdo_t *xdo, int hushable, const char *format, ...) {
 
   vfprintf(stderr, format, args);
   fprintf(stderr, "\n");
+  va_end(args);
 } /* _xdo_eprintf */
 
 void xdo_enable_feature(xdo_t *xdo, int feature) {

--- a/xdotool.c
+++ b/xdotool.c
@@ -661,6 +661,7 @@ void xdotool_debug(context_t *context, const char *format, ...) {
     vfprintf(stderr, format, args);
     fprintf(stderr, "\n");
   }
+  va_end(args);
 } /* xdotool_debug */
 
 void xdotool_output(context_t *context, const char *format, ...) {
@@ -671,4 +672,5 @@ void xdotool_output(context_t *context, const char *format, ...) {
   vfprintf(stdout, format, args);
   fprintf(stdout, "\n");
   fflush(stdout);
+  va_end(args);
 } /* xdotool_output */

--- a/xdotool.c
+++ b/xdotool.c
@@ -348,7 +348,7 @@ int script_main(int argc, char **argv) {
 
   if (context.xdo == NULL) {
     fprintf(stderr, "Failed creating new xdo instance\n");
-    return 1;
+    return EXIT_FAILURE;
   }
   context.xdo->debug = context.debug;
 


### PR DESCRIPTION
Use "return EXIT_FAILURE" when failing exit. Add va_end() after va_start()