### PR TITLE
add `xdotool type --aftermodifiers` option

### DIFF
--- a/cmd_click.c
+++ b/cmd_click.c
@@ -6,7 +6,7 @@ int cmd_click(context_t *context) {
   char *cmd = context->argv[0];
   int ret = 0;
   int clear_modifiers = 0;
-  int after_modifiers = 0;
+  int after_keys = 0;
   charcodemap_t *active_mods = NULL;
   int active_mods_n;
   char *window_arg = NULL;
@@ -15,12 +15,12 @@ int cmd_click(context_t *context) {
 
   int c;
   enum { 
-    opt_unused, opt_help, opt_clearmodifiers, opt_aftermodifiers, opt_window, opt_delay,
+    opt_unused, opt_help, opt_clearmodifiers, opt_afterkeys, opt_window, opt_delay,
     opt_repeat
   };
   static struct option longopts[] = {
     { "clearmodifiers", no_argument, NULL, opt_clearmodifiers },
-    { "aftermodifiers", no_argument, NULL, opt_aftermodifiers },
+    { "afterkeys", no_argument, NULL, opt_afterkeys },
     { "help", no_argument, NULL, opt_help },
     { "window", required_argument, NULL, opt_window },
     { "delay", required_argument, NULL, opt_delay },
@@ -30,7 +30,7 @@ int cmd_click(context_t *context) {
   static const char *usage = 
             "Usage: %s [options] <button>\n"
             "--clearmodifiers       - reset active modifiers (alt, etc) while moving\n"
-            "--aftermodifiers       - wait for modifiers to be released before typing\n"
+            "--afterkeys            - wait for all keys to be released before typing\n"
             "--window WINDOW        - specify a window to send click to\n"
             "--repeat REPEATS       - number of times to click. Default is 1\n"
             "--delay MILLISECONDS   - delay in milliseconds between clicks.\n"
@@ -55,8 +55,8 @@ int cmd_click(context_t *context) {
         clear_modifiers = 1;
         break;
       case 'a':
-      case opt_aftermodifiers:
-        after_modifiers = 1;
+      case opt_afterkeys:
+        after_keys = 1;
         break;
       case 'w':
       case opt_window:
@@ -93,8 +93,8 @@ int cmd_click(context_t *context) {
   button = atoi(context->argv[0]);
 
   window_each(context, window_arg, {
-    if (after_modifiers) {
-      xdo_wait_for_modifier_release(context->xdo);
+    if (after_keys) {
+      xdo_wait_for_key_release(context->xdo);
     }
     if (clear_modifiers) {
       xdo_get_active_modifiers(context->xdo, &active_mods, &active_mods_n);

--- a/cmd_key.c
+++ b/cmd_key.c
@@ -22,9 +22,11 @@ int cmd_key(context_t *context) {
 
   /* Options */
   int clear_modifiers = 0;
+  int after_modifiers = 0;
 
   static struct option longopts[] = {
     { "clearmodifiers", no_argument, NULL, 'c' },
+    { "aftermodifiers", no_argument, NULL, 'a' },
     { "delay", required_argument, NULL, 'd' },
     { "repeat-delay", required_argument, NULL, 'R' },
     { "help", no_argument, NULL, 'h' },
@@ -36,6 +38,7 @@ int cmd_key(context_t *context) {
   static const char *usage = 
      "Usage: %s [options] <keysequence> [keysequence ...]\n"
      "--clearmodifiers     - clear active keyboard modifiers during keystrokes\n"
+     "--aftermodifiers     - wait for modifiers to be released before typing\n"
      "--delay DELAY        - Use DELAY milliseconds between keystrokes\n"
      "--repeat TIMES       - How many times to repeat the key sequence\n"
      "--repeat-delay DELAY - DELAY milliseconds between repetitions\n"
@@ -51,7 +54,7 @@ int cmd_key(context_t *context) {
 
   int option_index;
 
-  while ((c = getopt_long_only(context->argc, context->argv, "+d:hcw:",
+  while ((c = getopt_long_only(context->argc, context->argv, "+d:hcaw:",
                                longopts, &option_index)) != -1) {
     switch (c) {
       case 'w':
@@ -61,6 +64,9 @@ int cmd_key(context_t *context) {
       case 'c':
         clear_modifiers = 1;
         break;
+      case 'a':
+	after_modifiers = 1;
+	break;
       case 'h':
         printf(usage, cmd);
         consume_args(context, context->argc);
@@ -115,6 +121,9 @@ int cmd_key(context_t *context) {
 
   int max_arg = context->argc;
   window_each(context, window_arg, {
+    if (after_modifiers) {
+      xdo_wait_for_modifier_release(context->xdo);
+    }
     if (clear_modifiers) {
       xdo_get_active_modifiers(context->xdo, &active_mods, &active_mods_n);
       xdo_clear_active_modifiers(context->xdo, window, active_mods, active_mods_n);

--- a/cmd_key.c
+++ b/cmd_key.c
@@ -22,11 +22,11 @@ int cmd_key(context_t *context) {
 
   /* Options */
   int clear_modifiers = 0;
-  int after_modifiers = 0;
+  int after_keys = 0;
 
   static struct option longopts[] = {
     { "clearmodifiers", no_argument, NULL, 'c' },
-    { "aftermodifiers", no_argument, NULL, 'a' },
+    { "afterkeys", no_argument, NULL, 'a' },
     { "delay", required_argument, NULL, 'd' },
     { "repeat-delay", required_argument, NULL, 'R' },
     { "help", no_argument, NULL, 'h' },
@@ -38,7 +38,7 @@ int cmd_key(context_t *context) {
   static const char *usage = 
      "Usage: %s [options] <keysequence> [keysequence ...]\n"
      "--clearmodifiers     - clear active keyboard modifiers during keystrokes\n"
-     "--aftermodifiers     - wait for modifiers to be released before typing\n"
+     "--afterkeys          - wait for all keys to be released before typing\n"
      "--delay DELAY        - Use DELAY milliseconds between keystrokes\n"
      "--repeat TIMES       - How many times to repeat the key sequence\n"
      "--repeat-delay DELAY - DELAY milliseconds between repetitions\n"
@@ -65,7 +65,7 @@ int cmd_key(context_t *context) {
         clear_modifiers = 1;
         break;
       case 'a':
-	after_modifiers = 1;
+	after_keys = 1;
 	break;
       case 'h':
         printf(usage, cmd);
@@ -121,8 +121,8 @@ int cmd_key(context_t *context) {
 
   int max_arg = context->argc;
   window_each(context, window_arg, {
-    if (after_modifiers) {
-      xdo_wait_for_modifier_release(context->xdo);
+    if (after_keys) {
+      xdo_wait_for_key_release(context->xdo);
     }
     if (clear_modifiers) {
       xdo_get_active_modifiers(context->xdo, &active_mods, &active_mods_n);

--- a/cmd_mousedown.c
+++ b/cmd_mousedown.c
@@ -8,11 +8,13 @@ int cmd_mousedown(context_t *context) {
   charcodemap_t *active_mods = NULL;
   int active_mods_n;
   int clear_modifiers = 0;
+  int after_modifiers = 0;
   char *window_arg = NULL;
 
   int c;
   static struct option longopts[] = {
     { "clearmodifiers", no_argument, NULL, 'c' },
+    { "aftermodifiers", no_argument, NULL, 'a' },
     { "help", no_argument, NULL, 'h' },
     { "window", required_argument, NULL, 'w' },
     { 0, 0, 0, 0 },
@@ -20,14 +22,19 @@ int cmd_mousedown(context_t *context) {
   static const char *usage =
             "Usage: %s [--clearmodifiers] [--window WINDOW] <button>\n"
             "--window <windowid>    - specify a window to send keys to\n"
-            "--clearmodifiers       - reset active modifiers (alt, etc) while typing\n";
+            "--clearmodifiers       - reset active modifiers (alt, etc) while clicking\n"
+            "--aftermodifiers       - wait for modifiers to be released before clicking\n";
+
   int option_index;
 
-  while ((c = getopt_long_only(context->argc, context->argv, "+chw:",
+  while ((c = getopt_long_only(context->argc, context->argv, "+cahw:",
                                longopts, &option_index)) != -1) {
     switch (c) {
       case 'c':
         clear_modifiers = 1;
+        break;
+      case 'a':
+        after_modifiers = 1;
         break;
       case 'h':
         printf(usage, cmd);
@@ -54,6 +61,9 @@ int cmd_mousedown(context_t *context) {
   button = atoi(context->argv[0]);
 
   window_each(context, window_arg, {
+    if (after_modifiers) {
+      xdo_wait_for_modifier_release(context->xdo);
+    }
     if (clear_modifiers) {
       xdo_get_active_modifiers(context->xdo, &active_mods, &active_mods_n);
       xdo_clear_active_modifiers(context->xdo, window, active_mods, active_mods_n);

--- a/cmd_mousedown.c
+++ b/cmd_mousedown.c
@@ -8,13 +8,13 @@ int cmd_mousedown(context_t *context) {
   charcodemap_t *active_mods = NULL;
   int active_mods_n;
   int clear_modifiers = 0;
-  int after_modifiers = 0;
+  int after_keys = 0;
   char *window_arg = NULL;
 
   int c;
   static struct option longopts[] = {
     { "clearmodifiers", no_argument, NULL, 'c' },
-    { "aftermodifiers", no_argument, NULL, 'a' },
+    { "afterkeys", no_argument, NULL, 'a' },
     { "help", no_argument, NULL, 'h' },
     { "window", required_argument, NULL, 'w' },
     { 0, 0, 0, 0 },
@@ -23,7 +23,7 @@ int cmd_mousedown(context_t *context) {
             "Usage: %s [--clearmodifiers] [--window WINDOW] <button>\n"
             "--window <windowid>    - specify a window to send keys to\n"
             "--clearmodifiers       - reset active modifiers (alt, etc) while clicking\n"
-            "--aftermodifiers       - wait for modifiers to be released before clicking\n";
+            "--afterkeys            - wait for all keys to be released before clicking\n";
 
   int option_index;
 
@@ -34,7 +34,7 @@ int cmd_mousedown(context_t *context) {
         clear_modifiers = 1;
         break;
       case 'a':
-        after_modifiers = 1;
+        after_keys = 1;
         break;
       case 'h':
         printf(usage, cmd);
@@ -61,8 +61,8 @@ int cmd_mousedown(context_t *context) {
   button = atoi(context->argv[0]);
 
   window_each(context, window_arg, {
-    if (after_modifiers) {
-      xdo_wait_for_modifier_release(context->xdo);
+    if (after_keys) {
+      xdo_wait_for_key_release(context->xdo);
     }
     if (clear_modifiers) {
       xdo_get_active_modifiers(context->xdo, &active_mods, &active_mods_n);

--- a/cmd_mousemove.c
+++ b/cmd_mousemove.c
@@ -5,7 +5,7 @@
 struct mousemove {
   Window window;
   int clear_modifiers;
-  int after_modifiers;
+  int after_keys;
   int opsync;
   int polar_coordinates;
   int x;
@@ -33,12 +33,12 @@ int cmd_mousemove(context_t *context) {
 
   int c;
   enum {
-    opt_unused, opt_help, opt_sync, opt_clearmodifiers, opt_aftermodifiers, opt_polar,
+    opt_unused, opt_help, opt_sync, opt_clearmodifiers, opt_afterkeys, opt_polar,
     opt_screen, opt_step, opt_delay, opt_window
   };
   static struct option longopts[] = {
     { "clearmodifiers", no_argument, NULL, opt_clearmodifiers },
-    { "aftermodifiers", no_argument, NULL, opt_aftermodifiers },
+    { "afterkeys", no_argument, NULL, opt_afterkeys },
     { "help", no_argument, NULL, opt_help},
     { "polar", no_argument, NULL, opt_polar },
     { "screen", required_argument, NULL, opt_screen },
@@ -51,7 +51,7 @@ int cmd_mousemove(context_t *context) {
   static const char *usage = 
       "Usage: %s [options] <x> <y>\n"
       "-c, --clearmodifiers      - reset active modifiers (alt, etc) while moving\n"
-      "-a, --aftermodifiers      - wait for modifiers to be released before moving\n"
+      "-a, --afterkeys           - wait for all keys to be released before moving\n"
 
       //"-d, --delay <MS>          - sleeptime in milliseconds between steps.\n"
       //"--step <STEP>             - pixels to move each time along path to x,y.\n" "-p, --polar               - Use polar coordinates. X as an angle, Y as distance\n"
@@ -68,8 +68,8 @@ int cmd_mousemove(context_t *context) {
         mousemove.clear_modifiers = 1;
         break;
       case 'a':
-      case opt_aftermodifiers:
-        mousemove.after_modifiers = 1;
+      case opt_afterkeys:
+        mousemove.after_keys = 1;
         break;
       case 'h':
       case opt_help:
@@ -195,8 +195,8 @@ static int _mousemove(context_t *context, struct mousemove *mousemove) {
   int mx, my, mscreen;
   xdo_get_mouse_location(context->xdo, &mx, &my, &mscreen);
 
-  if (mousemove->after_modifiers) {
-    xdo_wait_for_modifier_release(context->xdo);
+  if (mousemove->after_keys) {
+    xdo_wait_for_key_release(context->xdo);
   }
 
   if (mousemove->clear_modifiers) {

--- a/cmd_mousemove_relative.c
+++ b/cmd_mousemove_relative.c
@@ -7,7 +7,7 @@ int cmd_mousemove_relative(context_t *context) {
   char *cmd = *context->argv;
   int polar_coordinates = 0;
   int clear_modifiers = 0;
-  int after_modifiers = 0;
+  int after_keys = 0;
   int opsync = 0;
   int origin_x = -1, origin_y = -1;
 
@@ -15,20 +15,20 @@ int cmd_mousemove_relative(context_t *context) {
   int active_mods_n;
   int c;
   enum {
-    opt_unused, opt_help, opt_sync, opt_clearmodifiers, opt_aftermodifiers, opt_polar
+    opt_unused, opt_help, opt_sync, opt_clearmodifiers, opt_afterkeys, opt_polar
   };
   static struct option longopts[] = {
     { "help", no_argument, NULL, opt_help },
     { "sync", no_argument, NULL, opt_sync },
     { "polar", no_argument, NULL, opt_polar },
     { "clearmodifiers", no_argument, NULL, opt_clearmodifiers },
-    { "aftermodifiers", no_argument, NULL, opt_aftermodifiers },
+    { "afterkeys", no_argument, NULL, opt_afterkeys },
     { 0, 0, 0, 0 },
   };
   static const char *usage =
       "Usage: %s [options] <x> <y>\n"
       "-c, --clearmodifiers      - reset active modifiers (alt, etc) while moving\n"
-      "-a, --aftermodifiers      - wait for modifiers to be released before moving\n"
+      "-a, --afterkeys           - wait for all keys to be released before moving\n"
       "-p, --polar               - Use polar coordinates. X as an angle, Y as distance\n"
       "--sync                    - only exit once the mouse has moved\n"
       "\n"
@@ -63,7 +63,7 @@ int cmd_mousemove_relative(context_t *context) {
         clear_modifiers = 1;
         break;
       case 'a':
-      case opt_aftermodifiers:
+      case opt_afterkeys:
         clear_modifiers = 1;
         break;
       default:
@@ -102,8 +102,8 @@ int cmd_mousemove_relative(context_t *context) {
     y = (-sin(radians) * distance);
   }
  
-  if (after_modifiers) {
-    xdo_wait_for_modifier_release(context->xdo);
+  if (after_keys) {
+    xdo_wait_for_key_release(context->xdo);
   }
   if (clear_modifiers) {
     xdo_get_active_modifiers(context->xdo, &active_mods, &active_mods_n);

--- a/cmd_mouseup.c
+++ b/cmd_mouseup.c
@@ -9,12 +9,12 @@ int cmd_mouseup(context_t *context) {
   charcodemap_t *active_mods = NULL;
   int active_mods_n;
   int clear_modifiers = 0;
-  int after_modifiers = 0;
+  int after_keys = 0;
 
   int c;
   static struct option longopts[] = {
     { "clearmodifiers", no_argument, NULL, 'c' },
-    { "aftermodifiers", no_argument, NULL, 'a' },
+    { "afterkeys", no_argument, NULL, 'a' },
     { "help", no_argument, NULL, 'h' },
     { "window", required_argument, NULL, 'w' },
     { 0, 0, 0, 0 },
@@ -23,7 +23,7 @@ int cmd_mouseup(context_t *context) {
             "Usage: %s [--clearmodifiers] [--window WINDOW] <button>\n"
             "--window <windowid>    - specify a window to send keys to\n"
             "--clearmodifiers       - reset active modifiers (alt, etc) while clicking\n"
-            "--aftermodifiers       - wait for modifiers to be released before clicking\n";
+            "--afterkeys            - wait for all keys to be released before clicking\n";
   int option_index;
 
   while ((c = getopt_long_only(context->argc, context->argv, "+caw:h",
@@ -38,7 +38,7 @@ int cmd_mouseup(context_t *context) {
         clear_modifiers = 1;
         break;
       case 'a':
-        after_modifiers = 1;
+        after_keys = 1;
         break;
       case 'w':
         window_arg = strdup(optarg);
@@ -60,8 +60,8 @@ int cmd_mouseup(context_t *context) {
   button = atoi(context->argv[0]);
 
   window_each(context, window_arg, {
-    if (after_modifiers) {
-      xdo_wait_for_modifier_release(context->xdo);
+    if (after_keys) {
+      xdo_wait_for_key_release(context->xdo);
     }
     if (clear_modifiers) {
       xdo_get_active_modifiers(context->xdo, &active_mods, &active_mods_n);

--- a/cmd_mouseup.c
+++ b/cmd_mouseup.c
@@ -9,10 +9,12 @@ int cmd_mouseup(context_t *context) {
   charcodemap_t *active_mods = NULL;
   int active_mods_n;
   int clear_modifiers = 0;
+  int after_modifiers = 0;
 
   int c;
   static struct option longopts[] = {
     { "clearmodifiers", no_argument, NULL, 'c' },
+    { "aftermodifiers", no_argument, NULL, 'a' },
     { "help", no_argument, NULL, 'h' },
     { "window", required_argument, NULL, 'w' },
     { 0, 0, 0, 0 },
@@ -20,10 +22,11 @@ int cmd_mouseup(context_t *context) {
   static const char *usage =
             "Usage: %s [--clearmodifiers] [--window WINDOW] <button>\n"
             "--window <windowid>    - specify a window to send keys to\n"
-            "--clearmodifiers       - reset active modifiers (alt, etc) while typing\n";
+            "--clearmodifiers       - reset active modifiers (alt, etc) while clicking\n"
+            "--aftermodifiers       - wait for modifiers to be released before clicking\n";
   int option_index;
 
-  while ((c = getopt_long_only(context->argc, context->argv, "+cw:h",
+  while ((c = getopt_long_only(context->argc, context->argv, "+caw:h",
                                longopts, &option_index)) != -1) {
     switch (c) {
       case 'h':
@@ -33,6 +36,9 @@ int cmd_mouseup(context_t *context) {
         break;
       case 'c':
         clear_modifiers = 1;
+        break;
+      case 'a':
+        after_modifiers = 1;
         break;
       case 'w':
         window_arg = strdup(optarg);
@@ -54,6 +60,9 @@ int cmd_mouseup(context_t *context) {
   button = atoi(context->argv[0]);
 
   window_each(context, window_arg, {
+    if (after_modifiers) {
+      xdo_wait_for_modifier_release(context->xdo);
+    }
     if (clear_modifiers) {
       xdo_get_active_modifiers(context->xdo, &active_mods, &active_mods_n);
       xdo_clear_active_modifiers(context->xdo, window, active_mods, active_mods_n);

--- a/cmd_type.c
+++ b/cmd_type.c
@@ -26,17 +26,17 @@ int cmd_type(context_t *context) {
 
   /* Options */
   int clear_modifiers = 0;
-  int after_modifiers = 0;
+  int after_keys = 0;
   useconds_t delay = 12000; /* 12ms between keystrokes default */
 
   enum {
-    opt_unused, opt_clearmodifiers, opt_aftermodifiers, opt_delay, opt_help,
+    opt_unused, opt_clearmodifiers, opt_afterkeys, opt_delay, opt_help,
     opt_window, opt_args, opt_terminator, opt_file
   };
 
   struct option longopts[] = {
     { "clearmodifiers", no_argument, NULL, opt_clearmodifiers },
-    { "aftermodifiers", no_argument, NULL, opt_aftermodifiers },
+    { "afterkeys", no_argument, NULL, opt_afterkeys },
     { "delay", required_argument, NULL, opt_delay },
     { "help", no_argument, NULL, opt_help },
     { "window", required_argument, NULL, opt_window },
@@ -52,7 +52,7 @@ int cmd_type(context_t *context) {
     "--window <windowid>    - specify a window to send keys to\n"
     "--delay <milliseconds> - delay between keystrokes\n"
     "--clearmodifiers       - reset active modifiers (alt, etc) while typing\n"
-    "--aftermodifiers       - wait for modifiers to be released before typing\n"
+    "--afterkeys            - wait for all keys to be released before typing\n"
     "--args N  - how many arguments to expect in the exec command. This is\n"
     "            useful for ending an exec and continuing with more xdotool\n"
     "            commands\n"
@@ -79,8 +79,8 @@ int cmd_type(context_t *context) {
       case opt_clearmodifiers:
         clear_modifiers = 1;
         break;
-      case opt_aftermodifiers:
-        after_modifiers = 1;
+      case opt_afterkeys:
+        after_keys = 1;
         break;
       case opt_help:
         printf(usage, cmd);
@@ -186,8 +186,8 @@ int cmd_type(context_t *context) {
   }
 
   window_each(context, window_arg, {
-    if (after_modifiers) {
-      xdo_wait_for_modifier_release(context->xdo);
+    if (after_keys) {
+      xdo_wait_for_key_release(context->xdo);
     }
     if (clear_modifiers) {
       xdo_get_active_modifiers(context->xdo, &active_mods, &active_mods_n);

--- a/cmd_type.c
+++ b/cmd_type.c
@@ -187,13 +187,7 @@ int cmd_type(context_t *context) {
 
   window_each(context, window_arg, {
     if (after_modifiers) {
-      for (;;) {
-	xdo_get_active_modifiers(context->xdo, NULL, &active_mods_n);
-	if (active_mods_n == 0) {
-	  break;
-	}
-	usleep(30000);
-      }
+      xdo_wait_for_modifier_release(context->xdo);
     }
     if (clear_modifiers) {
       xdo_get_active_modifiers(context->xdo, &active_mods, &active_mods_n);

--- a/xdo.c
+++ b/xdo.c
@@ -1682,6 +1682,17 @@ int xdo_get_active_modifiers(const xdo_t *xdo, charcodemap_t **keys,
   return XDO_SUCCESS;
 }
 
+void xdo_wait_for_modifier_release(const xdo_t *xdo) {
+  int active_mods_n;
+  for (;;) {
+    xdo_get_active_modifiers(xdo, NULL, &active_mods_n);
+    if (active_mods_n == 0) {
+      return;
+    }
+    usleep(30000);
+  }
+}
+
 unsigned int xdo_get_input_state(const xdo_t *xdo) {
   Window root, dummy;
   int root_x, root_y, win_x, win_y;

--- a/xdo.h
+++ b/xdo.h
@@ -807,6 +807,11 @@ int xdo_get_active_modifiers(const xdo_t *xdo, charcodemap_t **keys,
                              int *nkeys);
 
 /**
+ * Wait for any currently pressed modifier keys to be released.
+ */
+void xdo_wait_for_modifier_release(const xdo_t *xdo);
+
+/**
  * Send any events necessary to clear the active modifiers.
  * For example, if you are holding 'alt' when xdo_get_active_modifiers is 
  * called, then this method will send a key-up for 'alt'

--- a/xdo.h
+++ b/xdo.h
@@ -809,7 +809,7 @@ int xdo_get_active_modifiers(const xdo_t *xdo, charcodemap_t **keys,
 /**
  * Wait for any currently pressed modifier keys to be released.
  */
-void xdo_wait_for_modifier_release(const xdo_t *xdo);
+void xdo_wait_for_key_release(const xdo_t *xdo);
 
 /**
  * Send any events necessary to clear the active modifiers.

--- a/xdotool.pod
+++ b/xdotool.pod
@@ -43,10 +43,10 @@ See also: L<SENDEVENT NOTES> and L<WINDOW STACK>
 
 Clear modifiers before sending keystrokes. See L<CLEARMODIFIERS> below.
 
-=item B<--aftermodifiers>
+=item B<--afterkeys>
 
-Wait for the user to release modifier keys before sending keystrokes.
-See L<AFTERMODIFIERS> below.
+Wait for the user to release all keys before sending keystrokes.
+See L<AFTERKEYS> below.
 
 =item B<--delay milliseconds>
 
@@ -110,10 +110,10 @@ Delay between keystrokes. Default is 12ms.
 
 Clear modifiers before sending keystrokes. See L<CLEARMODIFIERS> below.
 
-=item B<--aftermodifiers>
+=item B<--afterkeys>
 
-Wait for the user to release modifier keys before sending keystrokes.
-See L<AFTERMODIFIERS> below.
+Wait for the user to release all keys before sending keystrokes.
+See L<AFTERKEYS> below.
 
 =back
 
@@ -178,9 +178,9 @@ The origin defaults to the center of the current screen. If you specify a
 
 See L<CLEARMODIFIERS>
 
-=item B<--aftermodifiers>
+=item B<--afterkeys>
 
-See L<AFTERMODIFIERS>
+See L<AFTERKEYS>
 
 =item B<--sync>
 
@@ -224,9 +224,9 @@ in the general case than waiting for a specific target.
 
 See L<CLEARMODIFIERS>
 
-=item B<--aftermodifiers>
+=item B<--afterkeys>
 
-See L<AFTERMODIFIERS>
+See L<AFTERKEYS>
 
 =back
 
@@ -244,9 +244,9 @@ wheel up is 4, wheel down is 5.
 
 Clear modifiers before clicking. See L<CLEARMODIFIERS> below.
 
-=item B<--aftermodifiers>
+=item B<--afterkeys>
 
-Wait for modifiers to be released before clicking. See L<AFTERMODIFIERS> below.
+Wait for keys to be released before clicking. See L<AFTERKEYS> below.
 
 =item B<--repeat> REPEAT
 
@@ -1073,16 +1073,16 @@ The I<--clearmodifiers> flag can currently clear the following:
 
 =back
 
-=head1 AFTERMODIFIERS
+=head1 AFTERKEYS
 
-Any command taking the I<--aftermodifiers> flag will wait until any currently
-pressed modifier keys have been released before performing the action. It solves a
-similar problem to I<--clearmodifiers>, but does not attempt to restore the
-modifier state afterward.
+Any command taking the I<--afterkeys> flag will wait until any currently
+pressed keys have been released before performing the action, to avoid the
+end of a user's keyboard shortcut interfering with the beginning of xdotool's
+actions.
 
-I<--aftermodifiers> only waits for modifier keys, not mouse buttons or caps lock.
-If you use both I<--aftermodifiers> and I<--clearmodifiers>, the mouse buttons
-and caps lock state will still be cleared as described above.
+I<--afterkeys> only waits for key presses, not mouse buttons or caps lock state.
+If you use both I<--afterkeys> and I<--clearmodifiers>, I<--afterkeys> happens
+first, then the mouse buttons and caps lock state will be cleared as described above.
 
 =head1 SENDEVENT NOTES
 

--- a/xdotool.pod
+++ b/xdotool.pod
@@ -43,6 +43,11 @@ See also: L<SENDEVENT NOTES> and L<WINDOW STACK>
 
 Clear modifiers before sending keystrokes. See L<CLEARMODIFIERS> below.
 
+=item B<--aftermodifiers>
+
+Wait for the user to release modifier keys before sending keystrokes.
+See L<AFTERMODIFIERS> below.
+
 =item B<--delay milliseconds>
 
 Delay between keystrokes. Default is 12ms.
@@ -104,6 +109,11 @@ Delay between keystrokes. Default is 12ms.
 =item B<--clearmodifiers>
 
 Clear modifiers before sending keystrokes. See L<CLEARMODIFIERS> below.
+
+=item B<--aftermodifiers>
+
+Wait for the user to release modifier keys before sending keystrokes.
+See L<AFTERMODIFIERS> below.
 
 =back
 
@@ -168,6 +178,10 @@ The origin defaults to the center of the current screen. If you specify a
 
 See L<CLEARMODIFIERS>
 
+=item B<--aftermodifiers>
+
+See L<AFTERMODIFIERS>
+
 =item B<--sync>
 
 After sending the mouse move request, wait until the mouse is actually
@@ -210,6 +224,10 @@ in the general case than waiting for a specific target.
 
 See L<CLEARMODIFIERS>
 
+=item B<--aftermodifiers>
+
+See L<AFTERMODIFIERS>
+
 =back
 
 =item B<click> I<[options]> I<button>
@@ -225,6 +243,10 @@ wheel up is 4, wheel down is 5.
 =item B<--clearmodifiers>
 
 Clear modifiers before clicking. See L<CLEARMODIFIERS> below.
+
+=item B<--aftermodifiers>
+
+Wait for modifiers to be released before clicking. See L<AFTERMODIFIERS> below.
 
 =item B<--repeat> REPEAT
 
@@ -1037,7 +1059,7 @@ The order of operations if you hold shift while running 'xdotool key --clearmodi
 
 =back
 
-The I<--clearmodifiers> flag can currently clear of the following:
+The I<--clearmodifiers> flag can currently clear the following:
 
 =over
 
@@ -1050,6 +1072,17 @@ The I<--clearmodifiers> flag can currently clear of the following:
 
 
 =back
+
+=head1 AFTERMODIFIERS
+
+Any command taking the I<--aftermodifiers> flag will wait until any currently
+pressed modifier keys have been released before performing the action. It solves a
+similar problem to I<--clearmodifiers>, but does not attempt to restore the
+modifier state afterward.
+
+I<--aftermodifiers> only waits for modifier keys, not mouse buttons or caps lock.
+If you use both I<--aftermodifiers> and I<--clearmodifiers>, the mouse buttons
+and caps lock state will still be cleared as described above.
 
 =head1 SENDEVENT NOTES
 


### PR DESCRIPTION
This waits for the user to release any modifier keys that are currently held before starting to type. This allows avoiding race conditions when xdotool is called from a keyboard shortcut, and starts to type characters with the modifier still held. Currently the usual way to do so is with --clearmodifiers, but this introduces its own race conditions (see e.g. issue #43) if the physical key is released while the typing is in progress.