### PR TITLE
macos: Fix compile error implicit declaration of function 'strdup'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.o
+*.dylib
 *.so*
 *.1
 libxdo.pc

--- a/xdo.c
+++ b/xdo.c
@@ -7,7 +7,7 @@
  */
 
 #ifndef _XOPEN_SOURCE
-#define _XOPEN_SOURCE 500
+#define _XOPEN_SOURCE 600
 #endif /* _XOPEN_SOURCE */
 
 #include <sys/select.h>


### PR DESCRIPTION
Fixes #313 