### PR TITLE
`exec` command: Add support for window stack references (%1, %@, etc)

### DIFF
--- a/cmd_exec.c
+++ b/cmd_exec.c
@@ -145,8 +145,8 @@ int cmd_exec(context_t *context) {
   consume_args(context, command_count);
   free(terminator);
 
-  for (i=0; i < command_len; i++) {
-    free(command[i]);
+  for (size_t j=0; j < command_len; j++) {
+    free(command[j]);
   }
   free(command);
   return ret;


### PR DESCRIPTION
Window references will be replaced on the command-line in the same position that they occurred. In case of %@ (all windows), multiple arguments are inserted.

For example, if the window list is two entries: 123, 456

`exec echo Hello %2` will run the command exactly as this list
  [echo, "Hello", "456"]

`exec echo World %@` will run the command exactly as this list
  [echo, "World", "123", "456"]
with each window id being a separate argument.

For #431