### PR TITLE
`click`, `mousedown`, `mouseup`: optional position arguments

### DIFF
--- a/cmd_getmouselocation.c
+++ b/cmd_getmouselocation.c
@@ -1,22 +1,25 @@
 #include "xdo_cmd.h"
 
 int cmd_getmouselocation(context_t *context) {
-  int x, y, screen_num;
-  Window window;
+  int rx, ry, screen_num;
+  Window window_under_cursor;
   int ret;
   char *cmd = context->argv[0];
+  char *window_arg = NULL;
 
   int c;
   static struct option longopts[] = {
     { "help", no_argument, NULL, 'h' },
     { "shell", no_argument, NULL, 's' },
     { "prefix", required_argument, NULL, 'p' },
+    { "window", required_argument, NULL, 'w' },
     { 0, 0, 0, 0 },
   };
   static const char *usage = 
     "Usage: %s [--shell] [--prefix <STR>]\n"
-    "--shell      - output shell variables for use with eval\n"
-    "--prefix STR - use prefix for shell variables names (max 16 chars) \n";
+    "--window <windowid>    - get mouse location relative to window\n"
+    "--shell                - output shell variables for use with eval\n"
+    "--prefix STR           - use prefix for shell variables names (max 16 chars)\n";
   int option_index;
   int output_shell = 0;
   char out_prefix[17] = {'\0'};
@@ -28,6 +31,9 @@ int cmd_getmouselocation(context_t *context) {
         printf(usage, cmd);
         consume_args(context, context->argc);
         return EXIT_SUCCESS;
+        break;
+      case 'w':
+        window_arg = strdup(optarg);
         break;
       case 's':
         output_shell = 1;
@@ -44,20 +50,40 @@ int cmd_getmouselocation(context_t *context) {
 
   consume_args(context, optind);
 
-  ret = xdo_get_mouse_location2(context->xdo, &x, &y, &screen_num, &window);
+  ret = xdo_get_mouse_location2(context->xdo, &rx, &ry, &screen_num, &window_under_cursor);
+
+  int x = rx;
+  int y = ry;
+
+  int wx = COORDINATE_NONE;
+  int wy = COORDINATE_NONE;
+  if (window_arg) {
+    window_each(context, window_arg, {
+      xdo_translate_coordinates_to_window(context->xdo, window, rx, ry, &wx, &wy);
+      x = wx;
+      y = wy;
+    }); /* window_each(...) */
+  }
 
   if (output_shell) {
-    xdotool_output(context, "%sX=%d", out_prefix, x);
-    xdotool_output(context, "%sY=%d", out_prefix, y);
+    xdotool_output(context, "%sX=%d", out_prefix, rx);
+    xdotool_output(context, "%sY=%d", out_prefix, ry);
+    if (window_arg) {
+      xdotool_output(context, "%sWX=%d", out_prefix, wx);
+      xdotool_output(context, "%sWY=%d", out_prefix, wy);
+    }
     xdotool_output(context, "%sSCREEN=%d", out_prefix, screen_num);
-    xdotool_output(context, "%sWINDOW=%d", out_prefix, window);
+    xdotool_output(context, "%sWINDOW=%d", out_prefix, window_under_cursor);
   } else {
     /* only print if we're the last command */
     if (context->argc == 0) {
-      xdotool_output(context, "x:%d y:%d screen:%d window:%ld", x, y, screen_num, window);
+      xdotool_output(context, "x:%d y:%d screen:%d window:%ld", x, y, screen_num, window_under_cursor);
     }
-    window_save(context, window);
+    window_save(context, window_under_cursor);
   }
+
+  free(window_arg);
+
   return ret;
 }
 

--- a/cmd_mouseup.c
+++ b/cmd_mouseup.c
@@ -18,9 +18,12 @@ int cmd_mouseup(context_t *context) {
     { 0, 0, 0, 0 },
   };
   static const char *usage =
-            "Usage: %s [--clearmodifiers] [--window WINDOW] <button>\n"
+            "Usage: %s [--clearmodifiers] [--window WINDOW] <button> [<x> <y>]\n"
             "--window <windowid>    - specify a window to send keys to\n"
-            "--clearmodifiers       - reset active modifiers (alt, etc) while typing\n";
+            "--clearmodifiers       - reset active modifiers (alt, etc) while typing\n"
+            "\n"
+            "With x and y specified the event is dispatched in given position\n"
+            "(relative to WINDOW if specified) without moving the mouse pointer.\n";
   int option_index;
 
   while ((c = getopt_long_only(context->argc, context->argv, "+cw:h",
@@ -52,6 +55,16 @@ int cmd_mouseup(context_t *context) {
   }
 
   button = atoi(context->argv[0]);
+  consume_args(context, 1);
+
+  int x = COORDINATE_NONE;
+  int y = COORDINATE_NONE;
+  if (context->argc >= 2) {
+    if (is_numeric(context->argv[0]) && is_numeric(context->argv[1]))
+    x = atoi(context->argv[0]);
+    y = atoi(context->argv[1]);
+    consume_args(context, 2);
+  }
 
   window_each(context, window_arg, {
     if (clear_modifiers) {
@@ -59,7 +72,7 @@ int cmd_mouseup(context_t *context) {
       xdo_clear_active_modifiers(context->xdo, window, active_mods, active_mods_n);
     }
 
-    ret = xdo_mouse_up(context->xdo, window, button);
+    ret = xdo_mouse_up(context->xdo, window, button, x, y);
 
     if (clear_modifiers) {
       xdo_set_active_modifiers(context->xdo, window, active_mods, active_mods_n);
@@ -73,7 +86,6 @@ int cmd_mouseup(context_t *context) {
   }); /* window_each(...) */
 
   free(window_arg);
-  consume_args(context, 1);
   return ret;
 }
 

--- a/xdo.c
+++ b/xdo.c
@@ -65,7 +65,7 @@ static void _xdo_send_key(const xdo_t *xdo, Window window, charcodemap_t *key,
 static void _xdo_send_modifier(const xdo_t *xdo, int modmask, int is_press);
 
 static int _xdo_query_keycode_to_modifier(XModifierKeymap *modmap, KeyCode keycode);
-static int _xdo_mousebutton(const xdo_t *xdo, Window window, int button, int is_press);
+static int _xdo_mousebutton(const xdo_t* xdo, Window window, int button, int is_press, int x, int y);
 
 static int _is_success(const char *funcname, int code, const xdo_t *xdo);
 static void _xdo_debug(const xdo_t *xdo, const char *format, ...);
@@ -828,7 +828,7 @@ int xdo_move_mouse_relative(const xdo_t *xdo, int x, int y)  {
   return _is_success("XTestFakeRelativeMotionEvent", ret == 0, xdo);
 }
 
-int _xdo_mousebutton(const xdo_t *xdo, Window window, int button, int is_press) {
+int _xdo_mousebutton(const xdo_t *xdo, Window window, int button, int is_press, int x, int y) {
   int ret = 0;
 
   if (window == CURRENTWINDOW) {
@@ -857,6 +857,14 @@ int _xdo_mousebutton(const xdo_t *xdo, Window window, int button, int is_press) 
     xbpe.time = CurrentTime;
     xbpe.type = (is_press ? ButtonPress : ButtonRelease);
 
+    /* Use given position within the window */
+    if (x != COORDINATE_NONE && y != COORDINATE_NONE) {
+      xbpe.x = x;
+      xbpe.y = y;
+      XTranslateCoordinates(xdo->xdpy, xbpe.window, xbpe.root,
+                            xbpe.x, xbpe.y, &xbpe.x_root, &xbpe.y_root, &xbpe.subwindow);
+    }
+
     /* Get the coordinates of the cursor relative to xbpe.window and also find what
      * subwindow it might be on */
     XTranslateCoordinates(xdo->xdpy, xbpe.root, xbpe.window, 
@@ -881,12 +889,12 @@ int _xdo_mousebutton(const xdo_t *xdo, Window window, int button, int is_press) 
   }
 }
 
-int xdo_mouse_up(const xdo_t *xdo, Window window, int button) {
-  return _xdo_mousebutton(xdo, window, button, False);
+int xdo_mouse_up(const xdo_t *xdo, Window window, int button, int x, int y) {
+  return _xdo_mousebutton(xdo, window, button, False, x, y);
 }
 
-int xdo_mouse_down(const xdo_t *xdo, Window window, int button) {
-  return _xdo_mousebutton(xdo, window, button, True);
+int xdo_mouse_down(const xdo_t *xdo, Window window, int button, int x, int y) {
+  return _xdo_mousebutton(xdo, window, button, True, x, y);
 }
 
 int xdo_get_mouse_location(const xdo_t *xdo, int *x_ret, int *y_ret,
@@ -953,23 +961,27 @@ int xdo_get_mouse_location2(const xdo_t *xdo, int *x_ret, int *y_ret,
   return _is_success("XQueryPointer", ret == False, xdo);
 }
 
-int xdo_click_window(const xdo_t *xdo, Window window, int button) {
+int xdo_click_window(const xdo_t *xdo, Window window, int button, int x, int y) {
   int ret = 0;
-  ret = xdo_mouse_down(xdo, window, button);
+  ret = xdo_mouse_down(xdo, window, button, x, y);
   if (ret != XDO_SUCCESS) {
     fprintf(stderr, "xdo_mouse_down failed, aborting click.\n");
     return ret;
   }
   usleep(DEFAULT_DELAY);
-  ret = xdo_mouse_up(xdo, window, button);
+  ret = xdo_mouse_up(xdo, window, button, x, y);
   return ret;
 }
 
-int xdo_click_window_multiple(const xdo_t *xdo, Window window, int button,
+int xdo_click_window_multiple(const xdo_t *xdo, Window window, int button, int x, int y,
                        int repeat, useconds_t delay) {
   int ret = 0;
   while (repeat > 0) {
-    ret = xdo_click_window(xdo, window, button);
+    if (x != COORDINATE_NONE && y != COORDINATE_NONE) {
+      xdo_sent_enter_event(xdo, window);
+      xdo_sent_motion_event(xdo, window, x, y);
+    }
+    ret = xdo_click_window(xdo, window, button, x, y);
     if (ret != XDO_SUCCESS) {
       fprintf(stderr, "click failed with %d repeats remaining\n", repeat);
       return ret;
@@ -1705,15 +1717,15 @@ int xdo_clear_active_modifiers(const xdo_t *xdo, Window window, charcodemap_t *a
                           active_mods_n, False, NULL, DEFAULT_DELAY);
 
   if (input_state & Button1MotionMask)
-    ret = xdo_mouse_up(xdo, window, 1);
+    ret = xdo_mouse_up(xdo, window, 1, COORDINATE_NONE, COORDINATE_NONE);
   if (!ret && input_state & Button2MotionMask)
-    ret = xdo_mouse_up(xdo, window, 2);
+    ret = xdo_mouse_up(xdo, window, 2, COORDINATE_NONE, COORDINATE_NONE);
   if (!ret && input_state & Button3MotionMask)
-    ret = xdo_mouse_up(xdo, window, 3);
+    ret = xdo_mouse_up(xdo, window, 3, COORDINATE_NONE, COORDINATE_NONE);
   if (!ret && input_state & Button4MotionMask)
-    ret = xdo_mouse_up(xdo, window, 4);
+    ret = xdo_mouse_up(xdo, window, 4, COORDINATE_NONE, COORDINATE_NONE);
   if (!ret && input_state & Button5MotionMask)
-    ret = xdo_mouse_up(xdo, window, 5);
+    ret = xdo_mouse_up(xdo, window, 5, COORDINATE_NONE, COORDINATE_NONE);
   if (!ret && input_state & LockMask) {
     /* explicitly use down+up here since xdo_send_keysequence_window alone will track the modifiers
      * incurred by a key (like shift, or caps) and send them on the 'up' sequence.
@@ -1732,15 +1744,15 @@ int xdo_set_active_modifiers(const xdo_t *xdo, Window window, charcodemap_t *act
   xdo_send_keysequence_window_list_do(xdo, window, active_mods,
                           active_mods_n, True, NULL, DEFAULT_DELAY);
   if (input_state & Button1MotionMask)
-    ret = xdo_mouse_down(xdo, window, 1);
+    ret = xdo_mouse_down(xdo, window, 1, COORDINATE_NONE, COORDINATE_NONE);
   if (!ret && input_state & Button2MotionMask)
-    ret = xdo_mouse_down(xdo, window, 2);
+    ret = xdo_mouse_down(xdo, window, 2, COORDINATE_NONE, COORDINATE_NONE);
   if (!ret && input_state & Button3MotionMask)
-    ret = xdo_mouse_down(xdo, window, 3);
+    ret = xdo_mouse_down(xdo, window, 3, COORDINATE_NONE, COORDINATE_NONE);
   if (!ret && input_state & Button4MotionMask)
-    ret = xdo_mouse_down(xdo, window, 4);
+    ret = xdo_mouse_down(xdo, window, 4, COORDINATE_NONE, COORDINATE_NONE);
   if (!ret && input_state & Button5MotionMask)
-    ret = xdo_mouse_down(xdo, window, 5);
+    ret = xdo_mouse_down(xdo, window, 5, COORDINATE_NONE, COORDINATE_NONE);
   if (!ret && input_state & LockMask) {
     /* explicitly use down+up here since xdo_send_keysequence_window alone will track the modifiers
      * incurred by a key (like shift, or caps) and send them on the 'up' sequence.
@@ -1979,10 +1991,7 @@ int xdo_minimize_window(const xdo_t *xdo, Window window) {
   int ret;
   int screen;
 
-  /* Get screen number */
-  XWindowAttributes attr;
-  XGetWindowAttributes(xdo->xdpy, window, &attr);
-  screen = XScreenNumberOfScreen(attr.screen);
+  screen = xdo_get_screen_number_of_window(xdo, window);
 
   /* Minimize it */
   ret = XIconifyWindow(xdo->xdpy, window, screen);
@@ -2050,6 +2059,74 @@ int xdo_get_viewport_dimensions(xdo_t *xdo, unsigned int *width,
     Window root = RootWindow(xdo->xdpy, screen);
     return xdo_get_window_size(xdo, root, width, height);
   }
+}
+
+int xdo_sent_enter_event(const xdo_t *xdo, Window window) {
+  XEnterWindowEvent xev;
+  int screen_num = xdo_get_screen_number_of_window(xdo, window);
+
+  xev.type = EnterNotify;
+  xev.display = xdo->xdpy;
+  xev.window = window;
+  xev.root = RootWindow(xdo->xdpy, screen_num);
+  xev.subwindow = None;
+  xev.time = CurrentTime;
+  xev.state = 0;
+  xev.focus = False;
+  xev.same_screen = True;
+
+  return XSendEvent(xdo->xdpy, window, False, PointerMotionMask|ButtonMotionMask|MotionNotify, (XEvent *)&xev);
+}
+
+int xdo_sent_motion_event(const xdo_t *xdo, Window window, int x, int y) {
+  XMotionEvent xev;
+  int screen_num = xdo_get_screen_number_of_window(xdo, window);
+
+  xev.type = MotionNotify;
+  xev.display = xdo->xdpy;
+  xev.window = window;
+  xev.root = RootWindow(xdo->xdpy, screen_num);
+  xev.subwindow = None;
+  xev.time = CurrentTime;
+  xev.x = x;
+  xev.y = y;
+  xev.state = 0;
+  xev.is_hint = NotifyNormal;
+  xev.same_screen = True;
+
+  return XSendEvent(xdo->xdpy, window, False, PointerMotionMask|ButtonMotionMask|MotionNotify, (XEvent *)&xev);
+}
+
+int xdo_get_screen_number_of_window(const xdo_t *xdo, Window window) {
+  XWindowAttributes attr;
+  XGetWindowAttributes(xdo->xdpy, window, &attr);
+  return XScreenNumberOfScreen(attr.screen);
+}
+
+void xdo_translate_coordinates(const xdo_t *xdo,
+                               Window src_w, Window dest_w,
+                               int src_x, int src_y,
+                               int *dest_x_ret, int *dest_y_ret) {
+  Window unused_child;
+  XTranslateCoordinates(xdo->xdpy, src_w, dest_w, src_x, src_y, dest_x_ret, dest_y_ret, &unused_child);
+}
+
+void xdo_translate_coordinates_to_window(const xdo_t *xdo, Window dest_w,
+                                         int src_x, int src_y,
+                                         int *dest_x_ret, int *dest_y_ret) {
+  Window unused_child;
+  int screen_num = xdo_get_screen_number_of_window(xdo, dest_w);
+  Window root = RootWindow(xdo->xdpy, screen_num);
+  XTranslateCoordinates(xdo->xdpy, root, dest_w, src_x, src_y, dest_x_ret, dest_y_ret, &unused_child);
+}
+
+void xdo_translate_coordinates_to_root(const xdo_t *xdo, Window src_w,
+                                       int src_x, int src_y,
+                                       int *dest_x_ret, int *dest_y_ret) {
+  Window unused_child;
+  int screen_num = xdo_get_screen_number_of_window(xdo, src_w);
+  Window root = RootWindow(xdo->xdpy, screen_num);
+  XTranslateCoordinates(xdo->xdpy, src_w, root, src_x, src_y, dest_x_ret, dest_y_ret, &unused_child);
 }
 
 static int appears_to_be_wayland(Display *xdpy) {

--- a/xdo.h
+++ b/xdo.h
@@ -264,6 +264,8 @@ int xdo_move_mouse_relative_to_window(const xdo_t *xdo, Window window, int x, in
  */
 int xdo_move_mouse_relative(const xdo_t *xdo, int x, int y);
 
+#define COORDINATE_NONE -32768
+
 /**
  * Send a mouse press (aka mouse down) for a given button at the current mouse
  * location.
@@ -271,8 +273,10 @@ int xdo_move_mouse_relative(const xdo_t *xdo, int x, int y);
  * @param window The window you want to send the event to or CURRENTWINDOW
  * @param button The mouse button. Generally, 1 is left, 2 is middle, 3 is
  *    right, 4 is wheel up, 5 is wheel down.
+ * @param x the target X coordinate withing the window in pixels.
+ * @param y the target X coordinate withing the window in pixels.
  */
-int xdo_mouse_down(const xdo_t *xdo, Window window, int button);
+int xdo_mouse_down(const xdo_t *xdo, Window window, int button, int x, int y);
 
 /**
  * Send a mouse release (aka mouse up) for a given button at the current mouse
@@ -281,8 +285,10 @@ int xdo_mouse_down(const xdo_t *xdo, Window window, int button);
  * @param window The window you want to send the event to or CURRENTWINDOW
  * @param button The mouse button. Generally, 1 is left, 2 is middle, 3 is
  *    right, 4 is wheel up, 5 is wheel down.
+ * @param x the target X coordinate withing the window in pixels.
+ * @param y the target X coordinate withing the window in pixels.
  */
-int xdo_mouse_up(const xdo_t *xdo, Window window, int button);
+int xdo_mouse_up(const xdo_t *xdo, Window window, int button, int x, int y);
 
 /**
  * Get the current mouse location (coordinates and screen number).
@@ -340,7 +346,7 @@ int xdo_wait_for_mouse_move_to(const xdo_t *xdo, int dest_x, int dest_y);
  * @param button The mouse button. Generally, 1 is left, 2 is middle, 3 is
  *    right, 4 is wheel up, 5 is wheel down.
  */
-int xdo_click_window(const xdo_t *xdo, Window window, int button);
+int xdo_click_window(const xdo_t *xdo, Window window, int button, int x, int y);
 
 /**
  * Send a one or more clicks for a specific mouse button at the current mouse
@@ -350,7 +356,7 @@ int xdo_click_window(const xdo_t *xdo, Window window, int button);
  * @param button The mouse button. Generally, 1 is left, 2 is middle, 3 is
  *    right, 4 is wheel up, 5 is wheel down.
  */
-int xdo_click_window_multiple(const xdo_t *xdo, Window window, int button,
+int xdo_click_window_multiple(const xdo_t *xdo, Window window, int button, int x, int y,
                        int repeat, useconds_t delay);
 
 /**
@@ -935,6 +941,24 @@ int xdo_has_feature(xdo_t *xdo, int feature);
 int xdo_get_viewport_dimensions(xdo_t *xdo, unsigned int *width,
                                 unsigned int *height, int screen);
 
+int xdo_sent_enter_event(const xdo_t *xdo, Window window);
+
+int xdo_sent_motion_event(const xdo_t *xdo, Window window, int x, int y);
+
+int xdo_get_screen_number_of_window(const xdo_t *xdo, Window window);
+
+void xdo_translate_coordinates(const xdo_t *xdo,
+                               Window src_w, Window dest_w,
+                               int src_x, int src_y,
+                               int *dest_x_ret, int *dest_y_ret);
+
+void xdo_translate_coordinates_to_window(const xdo_t *xdo, Window dest_w,
+                                         int src_x, int src_y,
+                                         int *dest_x_ret, int *dest_y_ret);
+
+void xdo_translate_coordinates_to_root(const xdo_t *xdo, Window src_w,
+                                       int src_x, int src_y,
+                                       int *dest_x_ret, int *dest_y_ret);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/xdo_cmd.h
+++ b/xdo_cmd.h
@@ -24,6 +24,8 @@ extern "C" {
   "This command consumes all arguments after it, so you cannot chain\n" \
   " additional commands after it.\n"
 
+extern int is_numeric(const char *s);
+
 extern void consume_args(context_t *context, int argc);
 extern void window_list(context_t *context, const char *window_arg,
                         Window **windowlist_ret, int *nwindows_ret,

--- a/xdotool.c
+++ b/xdotool.c
@@ -32,6 +32,21 @@
 static int script_main(int argc, char **argv);
 static int args_main(int argc, char **argv);
 
+int is_numeric(const char *s) {
+  if (!s)  return 0; // null pointer
+  if (!*s) return 0; // empty string
+  if (*s == '-') { // "-N..."
+    s++;
+    if (!*s)          return 0; // "-"
+    if (!isdigit(*s)) return 0; // "-X"
+    s++;
+  }
+  while (*s) { // "...N..."
+    if (!isdigit(*s++)) return 0;
+  }
+  return 1; // OK
+}
+
 void consume_args(context_t *context, int argc) {
   if (argc > context->argc) {
     fprintf(stderr,


### PR DESCRIPTION
**click, mousedown, mouseup: optional position arguments**

```
Usage: %s [options] <button> [<x> <y>]

With x and y specified the event is dispatched in given position
(relative to WINDOW if specified) without moving the mouse pointer.
```

**getmouselocation: optional --window argument**

```
--window <windowid>    - get mouse location relative to window
```