### PR TITLE
fix potential null deref reported by static analyzer

### DIFF
--- a/xdo.c
+++ b/xdo.c
@@ -287,12 +287,6 @@ int xdo_translate_window_with_sizehint(const xdo_t *xdo, Window window,
     height *= hints.height_inc;
   } else {
     fprintf(stderr, "No size hints found for window %ld\n", window);
-    if (width_ret != NULL) {
-      *width_ret = width;
-    }
-    if (height_ret != NULL) {
-      *height_ret = width;
-    }
   }
 
   if (supplied_return & PBaseSize) {

--- a/xdo.c
+++ b/xdo.c
@@ -287,8 +287,12 @@ int xdo_translate_window_with_sizehint(const xdo_t *xdo, Window window,
     height *= hints.height_inc;
   } else {
     fprintf(stderr, "No size hints found for window %ld\n", window);
-    *width_ret = width;
-    *height_ret = width;
+    if (width_ret != NULL) {
+      *width_ret = width;
+    }
+    if (height_ret != NULL) {
+      *height_ret = width;
+    }
   }
 
   if (supplied_return & PBaseSize) {


### PR DESCRIPTION
Calling 'xdo_translate_window_with_sizehint' from 'xdo_set_window_size' shows both 'width_ret' and 'height_ret' could be null. Storing values into these pointers could be a null deref.

If these two pointers couldn't be null, then the condition in the following

```c
  if (width_ret != NULL) {
    *width_ret = width;
  }

  if (height_ret != NULL) {
    *height_ret = height;
  }
```

is redundant, this is a reversed null checking.