### PR TITLE
Fix bug where `sync` would wait if the mouse didn't need to move.

### DIFF
--- a/cmd_mousemove.c
+++ b/cmd_mousemove.c
@@ -218,8 +218,15 @@ static int _mousemove(context_t *context, struct mousemove *mousemove) {
     fprintf(stderr, "xdo_move_mouse reported an error\n");
   } else {
     if (mousemove->opsync) {
-      /* Wait until the mouse moves away from its current position */
-      xdo_wait_for_mouse_move_from(context->xdo, mx, my);
+      if (mx == x && my == y && mscreen == screen) {
+        /* Requested location is the same as the original mouse location, 
+         * so there's nothing to wait for */
+
+        // Blank, do nothing.
+      }  else {
+        /* Wait until the mouse moves away from its current position */
+        xdo_wait_for_mouse_move_from(context->xdo, mx, my);
+      }
     }
   }
 


### PR DESCRIPTION
A case where `xdotool mousemove --sync` is used, and the cursor is already at the requested position, xdotool would wait even though the cursor was already at the current position.

This happened because `mousemove --sync` waits for the cursor to move *away* from its current position, but if mousemove is given the position where the cursor already is, then `--sync` will cause it incorrectly to wait.

Reproducing this:

```
xdotool mousemove --sync 5 5     # works
xdotool mousemove --sync 5 5     # hangs until I move the mouse manually
```

Reported by @MXarko

Fixes #463