### PR TITLE
Fix heap corruption found by compiler warnings

### DIFF
--- a/xdo.c
+++ b/xdo.c
@@ -1643,7 +1643,7 @@ int xdo_get_active_modifiers(const xdo_t *xdo, charcodemap_t **keys,
 
         if (*nkeys == keys_size) {
           keys_size *= 2;
-          *keys = realloc(keys, keys_size * sizeof(charcodemap_t));
+          *keys = realloc(*keys, keys_size * sizeof(charcodemap_t));
         }
       }
     }

--- a/xdo_search.c
+++ b/xdo_search.c
@@ -35,7 +35,7 @@ int xdo_search_windows(const xdo_t *xdo, const xdo_search_t *search,
 
   unsigned int windowlist_size = 100;
   *nwindows_ret = 0;
-  *windowlist_ret = calloc(sizeof(Window), windowlist_size);
+  *windowlist_ret = calloc(windowlist_size, sizeof(Window));
 
   /* TODO(sissel): Support multiple screens */
   if (search->searchmask & SEARCH_SCREEN) {


### PR DESCRIPTION
Two fixes found by just compiling with recent gcc and reading the warnings:

The realloc change fixes a big bug.  The code was passing a pointer to a stack variable as the first argument to realloc.  It should pass the heap pointer that it wants to resize.

The calloc change is slightly more hypothetical.  By getting the arguments to calloc the wrong way around the correct size is allocated but it may be incorrectly aligned on some platforms.