### PR TITLE
Fixing nested xdo_find_window_client return code is not retained

### DIFF
--- a/xdo.c
+++ b/xdo.c
@@ -1234,6 +1234,7 @@ int xdo_find_window_client(const xdo_t *xdo, Window window, Window *window_ret,
         }
         if (children != NULL)
           XFree(children);
+        return ret;
       } else {
         fprintf(stderr, "Invalid find_client direction (%d)\n", direction);
         *window_ret = 0;


### PR DESCRIPTION
Fixes #191
When direction is XDO_FIND_CHILDREN for xdo_find_window_client, return code for the nested xdo_find_window_client was never retained (if nchildren > 0)

The fix is simply returning the return code we stored.