### PR TITLE
Fixed the race condition when traversing the window list using xdotool

### DIFF
--- a/xdo.c
+++ b/xdo.c
@@ -1860,8 +1860,8 @@ int xdo_set_active_modifiers(const xdo_t *xdo, Window window, charcodemap_t *act
 int xdo_get_pid_window(const xdo_t *xdo, Window window) {
   Atom type;
   int size;
-  long nitems;
-  unsigned char *data;
+  long nitems = 0;
+  unsigned char *data = NULL;
   int window_pid = 0;
 
   if (atom_NET_WM_PID == (Atom)-1) {


### PR DESCRIPTION
When `tdrop -a kitty` is executed for the first time, tdrop does not yet have cached window IDs (WIDs), and it must search for the window using `--pid`, which will cause a crash. Subsequent calls will not trigger a crash because the WIDs are cached in `/tmp/tdrop_$USER_$DISPLAY/wids/`.