### PR TITLE
Add `print_time` directive to print ns-timestamps from action chains for

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ CMDOBJS= cmd_click.o cmd_mousemove.o cmd_mousemove_relative.o cmd_mousedown.o \
          cmd_getwindowname.o cmd_getwindowclassname.o cmd_behave_screen_edge.o \
          cmd_windowminimize.o cmd_exec.o cmd_getwindowgeometry.o \
          cmd_windowclose.o cmd_windowquit.o \
-         cmd_sleep.o cmd_get_display_geometry.o
+         cmd_sleep.o cmd_get_display_geometry.o cmd_print_time.o
 
 .PHONY: all
 all: xdotool.1 libxdo.$(LIBSUFFIX) libxdo.$(VERLIBSUFFIX) xdotool

--- a/cmd_print_time.c
+++ b/cmd_print_time.c
@@ -1,0 +1,46 @@
+#include "xdo_cmd.h"
+#include <stdio.h>
+#include <time.h>
+
+#ifdef __APPLE__
+#  include "patch_clock_gettime.h"
+#endif
+
+int cmd_print_time(context_t *context) {
+  char *cmd = *context->argv;
+
+  /* Options processing largely just boilerplate right now, but someone may
+   * want to add --format or fd=1,2,open(path) or who knows what later. */
+  int c;
+  enum { opt_unused, opt_help };
+  static struct option longopts[] = {
+    { "help", no_argument, NULL, opt_help },
+    { 0, 0, 0, 0 },
+  };
+  static const char *usage =
+    "Usage: %s\n"
+    "Print the current time as seconds.nanoseconds since the Unix epoch,\n"
+    "using CLOCK_REALTIME. Intended for in action chains to timestamp events.\n"
+    "Example: xdotool print_time key --window WID Return\n";
+  int option_index;
+  while ((c = getopt_long_only(context->argc, context->argv, "+h",
+                               longopts, &option_index)) != -1) {
+    switch (c) {
+      case 'h':
+      case opt_help:
+        printf(usage, cmd);
+        consume_args(context, context->argc);
+        return EXIT_SUCCESS;
+      default:
+        fprintf(stderr, usage, cmd);
+        return EXIT_FAILURE;
+    }
+  }
+  consume_args(context, optind);
+
+  struct timespec ts;
+  clock_gettime(CLOCK_REALTIME, &ts);
+  printf("%ld.%09ld\n", (long)ts.tv_sec, (long)ts.tv_nsec);
+  fflush(stdout);
+  return EXIT_SUCCESS;
+}

--- a/xdotool.c
+++ b/xdotool.c
@@ -258,6 +258,7 @@ struct dispatch {
 
   { "exec", cmd_exec, },
   { "sleep", cmd_sleep, },
+  { "print_time", cmd_print_time, },
 
   { NULL, NULL, },
 };

--- a/xdotool.h
+++ b/xdotool.h
@@ -46,6 +46,7 @@ typedef struct context {
 int xdotool_main(int argc, char **argv);
 int cmd_exec(context_t *context);
 int cmd_sleep(context_t *context);
+int cmd_print_time(context_t *context);
 int cmd_behave(context_t *context);
 int cmd_behave_screen_edge(context_t *context);
 int cmd_click(context_t *context);


### PR DESCRIPTION
logging, benchmarking, etc.

As a more specific example, this can be used in combination with [10..50 microsecond character cell captures](https://github.com/c-blake/xm/blob/main/xmpkg/xrd.nim) to time UI response to keyboard events.  As a more complete realization of that example, this script can measure 'end-to-end' "press-Return until prompt finishes rendering" for a Zsh configuration:
```sh
#!/bin/sh
if [ $# -lt 1 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then cat <<EOF
Background: install \`xmpkg/xrd\` & patched (adds \`print_time\`) \`xdotool\`.
Point this @a window w/cleared screen/parent shell prompt at top-left.  Tell
script window ID as \$1 &as \$2 \$3 0-origin upper left character cell coords
s.t. altered=>"DONE".  Adjust \$CMD & \$RESET to keep this true trial-to-trial.

You can \`(repeat 25 tt \$w) > /t/d\` and then \`tim -w1 -o0 -r /t/d  tt\` to
estimate true minimum, but for user-visible latency, high quantiles (e.g. 99th
percentile) is more traditionally relevant.  (E.g. in network latency.)

Depending upon KB HW & OS kernel/USB drivers/etc, button-to-Xevent measured time
may be small by 6..17ms.  That also does NOT include video HW scanout to photon
generation time/speed-of-light travel time.  @60 Hz, the latter is likely
another ~17 ms/2 on average.  Instead, this measures the best portable software
lower bound to all that: the time for \`xdotool\` to loop its dispatch from
\`print_time\` to \`key\`, parse \`3 key\` args and then send a synthetic ENTER
press until the pixels arrive at the root window frame buffer.  This adds almost
surely < 1 ms while real keyboards + displays likely add 14..25 ms on average.

What real HW actually adds is harder to know.  Easiest end-to-end times come
from high speed video with frames of buttons going down & later frames of pixels
appearing.  Samsung S20+ supposedly has true 960 fps capture for ~1 ms/2 err.
Most iPhone/other Samsung do 240 fps w/AI super slomode interpolates.  Even ~2ms
err is more accurate than this script, but is IDIOSYNCRATIC TO ALL INVOLVED HW.
As with all end-to-end, info is "total" -- no breakdown to say where optimizing
effort/hw\$\$ may help (for example at the keyboard or at the display sides).
EOF
exit 1; fi
: "${W:=$1}"                    # E.g.: 0x600005; Only arg needed for terminals
: "${cx:=${2:-3}}"              # 0-origin '/' in "H:~/"
: "${cy:=${3:-1}}"              # 2nd terminal row
: "${CMD= zsh -l}"              # Default to Zsh TimeToFirstPrompt w/history- ..
: "${RESET= clear;exit}"        #..suppressing leading space.
: "${XD_TYPE:=type --delay 0 --window $W --args 1}" # Brevity is the soul of wit
: "${XD_ENTER:=key --window $W Return}"             # Another xdotool shortener
eval "$(xwininfo -id $W -frame |
        awk '/Absolute upper-left X:/{ printf("xo=%d;\n", $NF) }
             /Absolute upper-left Y:/{ printf("yo=%d;\n", $NF) }')"
eval "$(xwininfo -id $W -size |
        awk '/x resize increment/{ printf("dx=%d;\n", $NF) }
             /y resize increment/{ printf("dy=%d;\n", $NF) }')"
: "${RECT:=$((dx - 4))x$((dy - 4))+$((xo + cx*dx+2))+$((yo + cy*dy + 2))}"
#^^Watch the INNER BOX of char cell in case fonts bleed over edges by 2 pixels.
: "${HASH:=}" #-H-6046676558000083402 '0' in my test font; Intend use w/no "$.."

: "${TT_SIGS:=HUP INT TERM}"    # Overridable list of signals that imply cleanup
if [ "${T1-UNSET}" = "UNSET" ]; then
  T1=$(mktemp -- "${TMPDIR:-/dev/shm}/tt.XXX")||{ echo >&2 mktemp FAIL; exit 1;}
  T1_WAS_MADE=1; fi
export T1                       # --,"$T1" make even TMPDIR="-a b" work
clean() { [ "${T1_WAS_MADE-0}" -eq 1 ] && rm -f -- "$T1"; }
for s in $TT_SIGS; do trap "clean; trap - $s EXIT; kill -s $s "'"$$"' "$s"; done
trap clean EXIT                 # Subtle, but correct signal/exit temp clean-up

xrd -t0 -i "$RECT" $HASH >"$T1"& # -t0 => poll as fast as possible; ~10-50μs err
t0=$(xdotool $XD_TYPE "$CMD" print_time $XD_ENTER)
wait  # Measures from print_time to xrd seeing pixels
xdotool $XD_TYPE "$RESET" $XD_ENTER # Reset for repeat loops
T=$(cat "$T1")
[ ${#T} -gt 20 ] &&             # 10 pre-decimal + '.' + 9 to nanosecond
  awk -vt0="$t0" -vt1="${T%% *}" 'BEGIN{ printf("%.06f\ttt\n", t1 - t0) }' || {
    echo >&2 "xrd produced bad output; try again"; }
```